### PR TITLE
Fix tracebacks when nearby bluetooth device has no name

### DIFF
--- a/bluetti_bt_lib/scripts/bluetti_scan.py
+++ b/bluetti_bt_lib/scripts/bluetti_scan.py
@@ -18,6 +18,9 @@ async def scan_async():
     async def callback(device: BLEDevice, _):
         result = get_type_by_bt_name(device.name)
 
+        if result is None:
+            return
+
         if result is not None or device.name.startswith("PBOX"):
             found.append(device.address)
             stop_event.set()

--- a/bluetti_bt_lib/utils/device_info.py
+++ b/bluetti_bt_lib/utils/device_info.py
@@ -6,6 +6,10 @@ from ..devices import DEVICE_NAME_RE
 def get_type_by_bt_name(bt_name: str):
     """Check bluetooth name and return type if supported."""
 
+    # Some devices don't show up with a name.  re.match() will fail on None type
+    if bt_name is None:
+        return None
+
     match = DEVICE_NAME_RE.match(bt_name)
     if match is None:
         return None


### PR DESCRIPTION
When nearby bluetooth devices have no name, `bluetti_scan` spews tracebacks due to trying to execute `re.match()` on `None` type

This leverages return early pattern to gracefully handle these situations.

In `bluetti_scan` we need to check the result before the current `if` since otherwise we will traceback trying to execute `device.name.startswith()` when `device.name==None` (`None` doesn't have `.startswith()`

Since `get_type_by_bt_name` can already return `None`, this should be safe for any other code outside of `bluetti_scan` that calls `get_type_by_bt_name()`