### PR TITLE
bluetti_scan utility improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,16 @@ Commands included in this library should only be used for testing.
 ### Scan for supported devices
 
 ```bash
-usage: bluetti-scan [-h]
+usage: bluetti-scan [-h] [-r REGEX] [-s SCAN_TIME]
 
 Detect bluetti devices by bluetooth name
 
 options:
-  -h, --help  show this help message and exit
+  -h, --help            show this help message and exit
+  -r REGEX, --regex REGEX
+                        Custom regex to match device name
+  -s SCAN_TIME, --scan-time SCAN_TIME
+                        How long to scan for devices (seconds)
 ```
 
 Example output: `['EB3A', '00:00:00:00:00:00']`

--- a/bluetti_bt_lib/scripts/bluetti_scan.py
+++ b/bluetti_bt_lib/scripts/bluetti_scan.py
@@ -3,6 +3,7 @@
 import argparse
 import asyncio
 import logging
+import re
 from typing import List
 from bleak import BleakScanner
 from bleak.backends.device import BLEDevice
@@ -10,24 +11,35 @@ from bleak.backends.device import BLEDevice
 from ..utils.device_info import get_type_by_bt_name
 
 
-async def scan_async():
+async def scan_async(custom_regex, scan_time):
+    # maybe there is some other trigger we would want to stop scan on?
     stop_event = asyncio.Event()
+    # We can set the above event to prematurely stop the scan e.g. with `stop_event.set()`
 
     found: List[List[str]] = []
 
-    async def callback(device: BLEDevice, _):
-        result = get_type_by_bt_name(device.name)
+    print(f"Scanning for {scan_time} seconds (or until Ctrl+C)...")
 
-        if result is None:
+    async def callback(device: BLEDevice, _):
+        if device.name is None:
             return
 
+        if custom_regex:
+            match = re.match(custom_regex, device.name)
+            result = None if match is None else match[0]
+        else:
+            result = get_type_by_bt_name(device.name)
+
         if result is not None or device.name.startswith("PBOX"):
-            found.append(device.address)
-            stop_event.set()
-            print([result, device.address])
+            if not any(device.address in devices for devices in found):
+                found.append(device.address)
+                print([result, device.address])
 
     async with BleakScanner(callback):
-        await stop_event.wait()
+        try:
+            await asyncio.wait_for(stop_event.wait(), scan_time)
+        except (asyncio.exceptions.CancelledError, asyncio.TimeoutError):
+            exit()
 
 
 def start():
@@ -35,8 +47,22 @@ def start():
     parser = argparse.ArgumentParser(
         description="Detect bluetti devices by bluetooth name"
     )
-    parser.parse_args()
+    parser.add_argument(
+        "-r", "--regex", type=str, help="Custom regex to match device name"
+    )
+    parser.add_argument(
+        "-s",
+        "--scan-time",
+        type=int,
+        default=5,
+        help="How long to scan for devices (seconds)",
+    )
+    args = parser.parse_args()
 
     logging.basicConfig(level=logging.WARNING)
 
-    asyncio.run(scan_async())
+    asyncio.run(scan_async(args.regex, args.scan_time))
+
+
+if __name__ == "__main__":
+    start()


### PR DESCRIPTION
Adjusted the `bluetti_scan` utility to try and make it more useful. 
For example when scanning for new device to find MAC & then grab a `bluetti_read` or `bluetti_readall` from it.

- Returns multiple devices found instead of first one it finds
- To support multiple-device feature, it scans for 5 seconds by default (adjustable via CLI argument)
- Added ability to pass custom regex in for scanning new device types before they are added into the library 
- Can run script directly with `python -m bluetti_bt_lib.scripts.bluetti_scan`

