### PR TITLE
Add support for PR30V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Added and mostly validated by contributors (some are moved here from the HA Inte
 |EP500P     |bluetti-mqtt    |✅                   |✅            |✅            |✅             |✅             |
 |EP760      |@Apfuntimes     |✅                   |PV            |Grid          |❌             |AC Phases      |
 |EP800      |@jhagenk        |✅                   |❌            |❌            |❌             |❌             |
+|PR30V2     |@gentoo90       |✅                   |✅            |✅            |✅             |✅             |
 
 ## Controls
 

--- a/bluetti_bt_lib/devices/__init__.py
+++ b/bluetti_bt_lib/devices/__init__.py
@@ -23,6 +23,7 @@ from .ep500p import EP500P
 from .ep600 import EP600
 from .ep800 import EP800
 from .handsfree1 import Handsfree1
+from .pr30v2 import PR30V2
 
 # Add new device classes here
 DEVICES = {
@@ -49,9 +50,10 @@ DEVICES = {
     "EP600": EP600,
     "EP800": EP800,
     "Handsfree 1": Handsfree1,
+    "PR30V2": PR30V2,
 }
 
 # Prefixes of all currently supported devices
 DEVICE_NAME_RE = re.compile(
-    r"^(AC2A|AC50B|AC60|AC60P|AC70|AC70P|AC180|AC180T|AC180P|AC200L|AC200M|AC200PL|AC300|AC500|AP300|EB3A|EL100V2|EL30V2|EP500|EP500P|EP600|EP760|EP800|Handsfree\s1)(\d+)$"
+    r"^(AC2A|AC50B|AC60|AC60P|AC70|AC70P|AC180|AC180T|AC180P|AC200L|AC200M|AC200PL|AC300|AC500|AP300|EB3A|EL100V2|EL30V2|EP500|EP500P|EP600|EP760|EP800|Handsfree\s1|PR30V2)(\d+)$"
 )

--- a/bluetti_bt_lib/devices/pr30v2.py
+++ b/bluetti_bt_lib/devices/pr30v2.py
@@ -1,0 +1,15 @@
+from ..base_devices import BaseDeviceV2
+from ..fields import FieldName, UIntField, DecimalField
+
+
+class PR30V2(BaseDeviceV2):
+    def __init__(self):
+        super().__init__(
+            [
+                UIntField(FieldName.DC_OUTPUT_POWER, 140),
+                UIntField(FieldName.AC_OUTPUT_POWER, 142),
+                UIntField(FieldName.DC_INPUT_POWER, 144),
+                UIntField(FieldName.AC_INPUT_POWER, 146),
+                DecimalField(FieldName.AC_INPUT_VOLTAGE, 1314, 1),
+            ],
+        )


### PR DESCRIPTION
Bluetti Premium 30 V2 is almost the same as Elite 30 V2 (#8, #9) but with 320 instead of 288 Wh.
The device class is copypasted from `el30v2.py`