### PR TITLE
Scan: add -t/--timeout, dedupe by address, fix --timeout 0 hang

### DIFF
--- a/bluetti_bt_lib/scripts/bluetti_scan.py
+++ b/bluetti_bt_lib/scripts/bluetti_scan.py
@@ -1,33 +1,42 @@
-"""Bluetti scan command."""
+"""Bluetti scan command. Discovers devices by Bluetooth name; optional timeout for multi-device scan."""
 
 import argparse
 import asyncio
 import logging
-from typing import List
+from typing import Optional, Set
 from bleak import BleakScanner
 from bleak.backends.device import BLEDevice
 
 from ..utils.device_info import get_type_by_bt_name
 
 
-async def scan_async():
+async def scan_async(timeout_seconds: Optional[float] = None):
+    """Scan for Bluetti devices. With timeout: scan N seconds and list all. Without: stop at first device."""
     stop_event = asyncio.Event()
+    seen_addresses: Set[str] = set()  # deduplicate by address
 
-    found: List[List[str]] = []
+    def device_key(device: BLEDevice) -> str:
+        return (device.address or "").upper()
 
     async def callback(device: BLEDevice, _):
         result = get_type_by_bt_name(device.name)
-
-        if result is None:
+        if result is None and not (device.name or "").startswith("PBOX"):
             return
+        device_type = result if result is not None else "PBOX"
+        addr = device_key(device)
+        if addr in seen_addresses:
+            return
+        seen_addresses.add(addr)
+        print([device_type, device.address])
 
-        if result is not None or device.name.startswith("PBOX"):
-            found.append(device.address)
+        if timeout_seconds is None:
             stop_event.set()
-            print([result, device.address])
 
     async with BleakScanner(callback):
-        await stop_event.wait()
+        if timeout_seconds is not None:
+            await asyncio.sleep(timeout_seconds)
+        else:
+            await stop_event.wait()
 
 
 def start():
@@ -35,8 +44,17 @@ def start():
     parser = argparse.ArgumentParser(
         description="Detect bluetti devices by bluetooth name"
     )
-    parser.parse_args()
+    parser.add_argument(
+        "-t",
+        "--timeout",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help="Scan for this many seconds and list all discovered devices. "
+        "If omitted, stop after the first device is found.",
+    )
+    args = parser.parse_args()
 
     logging.basicConfig(level=logging.WARNING)
 
-    asyncio.run(scan_async())
+    asyncio.run(scan_async(timeout_seconds=args.timeout))


### PR DESCRIPTION
# PR 1: Scan – timeout, dedupe, fix --timeout 0 hang

## Summary
Improves `bluetti-scan` with an optional duration mode, deduplication by address, and a fix for `--timeout 0` hanging.

## Changes
- **`-t / --timeout SECONDS`** (optional): When set, scan for the given number of seconds and list every discovered device once. When omitted, behavior is unchanged: stop as soon as the first supported device is found.
- **Deduplication by address**: Each device is reported at most once (by BLE address), so long timeouts no longer repeat the same device.
- **PBOX handling**: Devices whose name starts with `PBOX` are included in timeout mode and reported as type `PBOX`.
- **`--timeout 0` fix**: A zero timeout no longer hangs. The condition now uses `timeout_seconds is not None` (instead of `... and timeout_seconds > 0`), so `asyncio.sleep(0)` runs and the scanner exits instead of waiting on `stop_event`, which is never set when a numeric timeout is provided.

## Usage
```bash
# Legacy: stop at first device
bluetti-scan

# Scan 15 seconds, list all devices (deduplicated)
bluetti-scan --timeout 15

# Zero timeout: exit immediately (no hang)
bluetti-scan --timeout 0
```

## Testing
- Run `bluetti-scan` with no args: should stop at first device.
- Run `bluetti-scan --timeout 5`: should run ~5 seconds and list devices.
- Run `bluetti-scan --timeout 0`: should exit immediately without hanging.
