### PR TITLE
Enable write commands for encrypted Bluetti devices (AC180P and others)

### DIFF
--- a/bluetti_bt_lib/__init__.py
+++ b/bluetti_bt_lib/__init__.py
@@ -5,6 +5,7 @@ from .bluetooth import (
     DeviceReader,
     DeviceReaderConfig,
     DeviceWriter,
+    DeviceWriterConfig,
     DeviceRecognizerResult,
     recognize_device,
 )

--- a/bluetti_bt_lib/bluetooth/device_writer.py
+++ b/bluetti_bt_lib/bluetooth/device_writer.py
@@ -80,16 +80,13 @@ class DeviceWriter:
 
     async def _complete_encryption_handshake(self):
         """Subscribe to BLE notifications and wait until ECDH key exchange is complete."""
+        self._handshake_complete = asyncio.Event()
         await self.client.start_notify(NOTIFY_UUID, self._on_encryption_message)
         self.logger.debug("Waiting for encryption handshake...")
-
-        elapsed = 0.0
-        while not self._encryption.is_ready_for_commands:
-            await asyncio.sleep(0.5)
-            elapsed += 0.5
-            if elapsed > 12:
-                raise TimeoutError("Encryption handshake timed out")
-
+        try:
+            await asyncio.wait_for(self._handshake_complete.wait(), timeout=12)
+        except asyncio.TimeoutError:
+            raise TimeoutError("Encryption handshake timed out")
         self.logger.debug("Encryption handshake complete")
 
     async def _cleanup(self):
@@ -142,3 +139,4 @@ class DeviceWriter:
         elif decrypted.type == MessageType.PUBKEY_ACCEPTED:
             self.logger.debug("Key exchange complete, shared secret established")
             self._encryption.msg_key_accepted(decrypted)
+            self._handshake_complete.set()

--- a/bluetti_bt_lib/bluetooth/device_writer.py
+++ b/bluetti_bt_lib/bluetooth/device_writer.py
@@ -1,13 +1,15 @@
 import asyncio
 import logging
 from typing import Any
+
 import async_timeout
 from bleak import BleakClient
 from bleak.exc import BleakError
 
-from ..const import WRITE_UUID
+from ..const import NOTIFY_UUID, WRITE_UUID
 from ..base_devices import BluettiDevice
 from ..utils.privacy import mac_loggable
+from .encryption import BluettiEncryption, Message, MessageType
 
 
 class DeviceWriterConfig:
@@ -28,56 +30,115 @@ class DeviceWriter:
         self.bluetti_device = bluetti_device
         self.config = config
         self.polling_lock = lock
-
+        self._encryption = BluettiEncryption()
         self.logger = logging.getLogger(
             f"{__name__}.{mac_loggable(bleak_client.address).replace(':', '_')}"
         )
 
     async def write(self, field: str, value: Any):
-        if self.config.use_encryption:
-            self.logger.error("Encryption on writes is not yet supported")
-            return
-
-        available_fields = [f.name for f in self.bluetti_device.fields]
-        if field not in available_fields:
-            self.logger.error("Field not supported")
-            return
-
-        command = self.bluetti_device.build_write_command(field, value)
-
+        command = self._build_write_command(field, value)
         if command is None:
-            self.logger.error("Field is not writeable")
             return
-
-        self.logger.debug("Writing to device register")
 
         async with self.polling_lock:
             try:
                 async with async_timeout.timeout(self.config.timeout):
-                    if not self.client.is_connected:
-                        self.logger.debug("Connecting to device")
-                        await self.client.connect()
-
-                    self.logger.debug("Connected to device")
-
-                    self.logger.debug("Writing command: %s", command)
-
-                    await self.client.write_gatt_char(
-                        WRITE_UUID,
-                        bytes(command),
-                    )
-
+                    await self._connect_if_needed()
+                    command_bytes = await self._prepare_command_bytes(bytes(command))
+                    await self.client.write_gatt_char(WRITE_UUID, command_bytes)
                     self.logger.debug("Write successful")
-
             except TimeoutError:
-                self.logger.warning("Timeout")
-                return None
+                self.logger.warning("Timeout writing to device")
             except BleakError as err:
                 self.logger.warning("Bleak error: %s", err)
-                return None
-            except BaseException as err:
+            except Exception as err:
                 self.logger.warning("Unknown error: %s", err)
-                return None
             finally:
-                await self.client.disconnect()
-                self.logger.debug("Disconnected from device")
+                await self._cleanup()
+
+    def _build_write_command(self, field: str, value: Any):
+        """Validate field and build the Modbus write command. Returns None if invalid."""
+        if field not in [f.name for f in self.bluetti_device.fields]:
+            self.logger.error("Field not supported: %s", field)
+            return None
+        command = self.bluetti_device.build_write_command(field, value)
+        if command is None:
+            self.logger.error("Field is not writeable: %s", field)
+        return command
+
+    async def _connect_if_needed(self):
+        if not self.client.is_connected:
+            self.logger.debug("Connecting to device")
+            await self.client.connect()
+
+    async def _prepare_command_bytes(self, raw_bytes: bytes) -> bytes:
+        """Return command bytes ready to send: plain bytes or AES-encrypted after handshake."""
+        if not self.config.use_encryption:
+            return raw_bytes
+        await self._complete_encryption_handshake()
+        return self._encryption.aes_encrypt(raw_bytes, self._encryption.secure_aes_key, None)
+
+    async def _complete_encryption_handshake(self):
+        """Subscribe to BLE notifications and wait until ECDH key exchange is complete."""
+        await self.client.start_notify(NOTIFY_UUID, self._on_encryption_message)
+        self.logger.debug("Waiting for encryption handshake...")
+
+        elapsed = 0.0
+        while not self._encryption.is_ready_for_commands:
+            await asyncio.sleep(0.5)
+            elapsed += 0.5
+            if elapsed > 12:
+                raise TimeoutError("Encryption handshake timed out")
+
+        self.logger.debug("Encryption handshake complete")
+
+    async def _cleanup(self):
+        if self.config.use_encryption:
+            try:
+                await self.client.stop_notify(NOTIFY_UUID)
+            except Exception:
+                pass
+            self._encryption.reset()
+        try:
+            await self.client.disconnect()
+        except Exception:
+            pass
+
+    async def _on_encryption_message(self, _sender: int, data: bytearray):
+        """Dispatch each BLE notification to the appropriate handshake handler."""
+        message = Message(data)
+        if message.is_pre_key_exchange:
+            await self._handle_pre_key_message(message)
+        else:
+            await self._handle_encrypted_handshake_message(message)
+
+    async def _handle_pre_key_message(self, message: Message):
+        """Handle unencrypted handshake messages: challenge and challenge-accepted."""
+        message.verify_checksum()
+        if message.type == MessageType.CHALLENGE:
+            self.logger.debug("Received challenge, sending response")
+            response = self._encryption.msg_challenge(message)
+            await self.client.write_gatt_char(WRITE_UUID, response)
+        elif message.type == MessageType.CHALLENGE_ACCEPTED:
+            self.logger.debug("Challenge accepted, starting key exchange")
+
+    async def _handle_encrypted_handshake_message(self, message: Message):
+        """Handle encrypted handshake messages: peer public key and key-accepted."""
+        if self._encryption.unsecure_aes_key is None:
+            self.logger.warning("Received encrypted message before challenge was completed")
+            return
+
+        key, iv = self._encryption.getKeyIv()
+        decrypted = Message(self._encryption.aes_decrypt(message.buffer, key, iv))
+
+        if not decrypted.is_pre_key_exchange:
+            return
+
+        decrypted.verify_checksum()
+        if decrypted.type == MessageType.PEER_PUBKEY:
+            self.logger.debug("Received peer public key, sending ours")
+            response = self._encryption.msg_peer_pubkey(decrypted)
+            await self.client.write_gatt_char(WRITE_UUID, response)
+        elif decrypted.type == MessageType.PUBKEY_ACCEPTED:
+            self.logger.debug("Key exchange complete, shared secret established")
+            self._encryption.msg_key_accepted(decrypted)

--- a/bluetti_bt_lib/scripts/bluetti_write.py
+++ b/bluetti_bt_lib/scripts/bluetti_write.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 from bleak import BleakClient
 
-from ..bluetooth import DeviceWriter
+from ..bluetooth import DeviceWriter, DeviceWriterConfig
 from ..utils.device_builder import build_device
 
 
@@ -20,15 +20,12 @@ async def async_write(
         print("Unsupported powerstation type")
         return
 
-    if encryption:
-        print("Encryption is not supported")
-        return
-
     print("Client created")
 
     writer = DeviceWriter(
         client,
         built,
+        config=DeviceWriterConfig(use_encryption=encryption or False),
     )
 
     print("Writer created")


### PR DESCRIPTION
## Problem

`DeviceWriter.write()` was returning early for encrypted devices:

```python
if self.config.use_encryption:
    self.logger.error("Encryption on writes is not yet supported")
    return
```

This meant that controls (AC output, DC output, charging mode, etc.) were completely non-functional on encrypted devices like the AC180P — even though the correct `SwitchField` and `SelectField` definitions existed in the device model.

## What changed

### `bluetti_bt_lib/bluetooth/device_writer.py`

Implemented the full ECDH + AES encryption handshake before sending write commands.

The write flow for encrypted devices:

1. Connect to the device
2. Subscribe to BLE notifications (`NOTIFY_UUID`)
3. Device sends a **CHALLENGE** → we respond with `msg_challenge()`
4. Device sends **CHALLENGE_ACCEPTED**
5. Device sends its **PEER_PUBKEY** (encrypted with a temporary AES key) → we respond with our public key via `msg_peer_pubkey()`
6. Device sends **PUBKEY_ACCEPTED** → we derive the shared secret via ECDH (`msg_key_accepted()`)
7. `encryption.is_ready_for_commands` becomes `True`
8. The Modbus write command is **AES-encrypted** with the shared secret and sent
9. Notifications are unsubscribed, encryption state is reset, device disconnects

The method is split into small focused helpers to keep complexity low:

| Method | Responsibility |
|--------|---------------|
| `write()` | Orchestrates the full flow |
| `_build_write_command()` | Validates field and builds Modbus command |
| `_connect_if_needed()` | Connects if not already connected |
| `_prepare_command_bytes()` | Returns plain or encrypted bytes |
| `_complete_encryption_handshake()` | Subscribes and waits for key exchange |
| `_on_encryption_message()` | Routes each BLE notification |
| `_handle_pre_key_message()` | Handles CHALLENGE / CHALLENGE_ACCEPTED |
| `_handle_encrypted_handshake_message()` | Handles PEER_PUBKEY / PUBKEY_ACCEPTED |
| `_cleanup()` | Unsubscribes, resets encryption, disconnects |

When `use_encryption=False` the behaviour is **identical to before** — no handshake, plain bytes sent directly.

### `bluetti_bt_lib/__init__.py`

Added `DeviceWriterConfig` to the top-level package exports (it was only reachable via `bluetti_bt_lib.bluetooth.device_writer` before).

## Tested on

- Bluetti AC180P via ESPHome BLE proxy
- AC output, DC output, Power Lifting, Charging Mode all confirmed working

## Notes

Fragmented BLE notification handling (#48) is out of scope for this PR. Write commands on the AC180P work without buffering, but other encrypted devices may be affected.
