### PR TITLE
Persistent BLE connection for instant writes and original app compatibility 

### DIFF
--- a/bluetti_bt_lib/__init__.py
+++ b/bluetti_bt_lib/__init__.py
@@ -5,6 +5,7 @@ from .bluetooth import (
     DeviceReader,
     DeviceReaderConfig,
     DeviceWriter,
+    DeviceWriterConfig,
     DeviceRecognizerResult,
     recognize_device,
 )

--- a/bluetti_bt_lib/__init__.py
+++ b/bluetti_bt_lib/__init__.py
@@ -2,6 +2,7 @@
 
 from .base_devices import BluettiDevice
 from .bluetooth import (
+    DeviceConnection,
     DeviceReader,
     DeviceReaderConfig,
     DeviceWriter,

--- a/bluetti_bt_lib/bluetooth/__init__.py
+++ b/bluetti_bt_lib/bluetooth/__init__.py
@@ -1,3 +1,4 @@
+from .device_connection import *
 from .device_reader import *
 from .device_writer import *
 from .device_recognizer import *

--- a/bluetti_bt_lib/bluetooth/device_connection.py
+++ b/bluetti_bt_lib/bluetooth/device_connection.py
@@ -1,0 +1,187 @@
+import asyncio
+import logging
+from typing import Callable
+
+from bleak import BleakScanner
+from bleak.backends.device import BLEDevice
+from bleak.exc import BleakError
+from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
+
+from ..const import NOTIFY_UUID, WRITE_UUID
+from ..utils.privacy import mac_loggable
+from .encryption import BluettiEncryption, Message, MessageType
+
+
+class DeviceConnection:
+    """Manages a persistent BLE connection shared between DeviceReader and DeviceWriter.
+
+    Owns the BleakClient and BluettiEncryption session. Handles the ECDH handshake
+    once on connect, then routes incoming notifications:
+    - Handshake messages are handled internally.
+    - Modbus data responses are dispatched to the data_callback set by DeviceReader.
+    """
+
+    def __init__(self, address: str, use_encryption: bool = False) -> None:
+        self._address = address
+        self._use_encryption = use_encryption
+        self._client: BleakClientWithServiceCache | None = None
+        self._encryption = BluettiEncryption()
+        self._handshake_complete: asyncio.Event | None = None
+        self._data_callback: Callable[[bytes], None] | None = None
+        self.logger = logging.getLogger(
+            f"{__name__}.{mac_loggable(address).replace(':', '_')}"
+        )
+
+    @property
+    def address(self) -> str:
+        return self._address
+
+    @property
+    def client(self) -> BleakClientWithServiceCache | None:
+        return self._client
+
+    @property
+    def encryption(self) -> BluettiEncryption:
+        return self._encryption
+
+    @property
+    def is_connected(self) -> bool:
+        return self._client is not None and self._client.is_connected
+
+    def set_data_callback(self, callback: Callable[[bytes], None]) -> None:
+        """Called by DeviceReader before sending a command to receive the response."""
+        self._data_callback = callback
+
+    def clear_data_callback(self) -> None:
+        """Called by DeviceReader after receiving the response."""
+        self._data_callback = None
+
+    async def connect(self) -> bool:
+        """Scan for device, establish connection, run ECDH handshake if needed."""
+        self._encryption.reset()
+        try:
+            device = await self._find_device()
+            if device is None:
+                return False
+            self._client = await self._establish_client(device)
+            await self._subscribe_notifications()
+            if self._use_encryption:
+                await self._wait_for_handshake()
+            self.logger.debug("Connected successfully")
+            return True
+        except (BleakError, TimeoutError, asyncio.TimeoutError) as err:
+            self.logger.warning("Connection failed: %s", err)
+            return False
+
+    async def ensure_connected(self) -> bool:
+        """Reconnect if the connection was dropped."""
+        if self.is_connected:
+            return True
+        self.logger.debug("Connection lost, reconnecting")
+        return await self.connect()
+
+    async def disconnect(self) -> None:
+        """Explicitly close the connection and reset encryption state."""
+        await self._stop_notifications()
+        await self._disconnect_client()
+        self._encryption.reset()
+        self._client = None
+
+    async def _find_device(self) -> BLEDevice | None:
+        """Scan BLE for the device by address."""
+        self.logger.debug("Scanning for device %s", mac_loggable(self._address))
+        device = await BleakScanner.find_device_by_address(self._address, timeout=5)
+        if device is None:
+            self.logger.error("Device not found: %s", mac_loggable(self._address))
+        return device
+
+    async def _establish_client(self, device: BLEDevice) -> BleakClientWithServiceCache:
+        """Create and connect a BleakClient using bleak_retry_connector."""
+        self.logger.debug("Establishing connection")
+        return await establish_connection(
+            BleakClientWithServiceCache,
+            device,
+            device.name or "Unknown Device",
+            max_attempts=10,
+        )
+
+    async def _subscribe_notifications(self) -> None:
+        """Register the single notification handler on NOTIFY_UUID."""
+        await self._client.start_notify(NOTIFY_UUID, self._on_notification)
+        self.logger.debug("Notification handler registered")
+
+    async def _wait_for_handshake(self) -> None:
+        """Wait until the ECDH key exchange is complete."""
+        self._handshake_complete = asyncio.Event()
+        self.logger.debug("Waiting for encryption handshake")
+        try:
+            await asyncio.wait_for(self._handshake_complete.wait(), timeout=12)
+        except asyncio.TimeoutError:
+            raise TimeoutError("Encryption handshake timed out")
+        self.logger.debug("Encryption handshake complete")
+
+    async def _on_notification(self, _sender: int, data: bytearray) -> None:
+        """Route each incoming BLE notification to the right handler."""
+        message = Message(data)
+        if message.is_pre_key_exchange:
+            await self._handle_pre_key_message(message)
+        elif self._use_encryption:
+            await self._handle_encrypted_message(message)
+        else:
+            self._dispatch_data(bytes(data))
+
+    async def _handle_pre_key_message(self, message: Message) -> None:
+        """Handle unencrypted handshake: CHALLENGE and CHALLENGE_ACCEPTED."""
+        message.verify_checksum()
+        if message.type == MessageType.CHALLENGE:
+            self.logger.debug("Received challenge, sending response")
+            response = self._encryption.msg_challenge(message)
+            await self._client.write_gatt_char(WRITE_UUID, response)
+        elif message.type == MessageType.CHALLENGE_ACCEPTED:
+            self.logger.debug("Challenge accepted, starting key exchange")
+
+    async def _handle_encrypted_message(self, message: Message) -> None:
+        """Decrypt the message, then route to key exchange or data handler."""
+        if self._encryption.unsecure_aes_key is None:
+            self.logger.warning("Received encrypted message before challenge completed")
+            return
+        key, iv = self._encryption.getKeyIv()
+        decrypted = Message(self._encryption.aes_decrypt(message.buffer, key, iv))
+        if decrypted.is_pre_key_exchange:
+            await self._handle_encrypted_key_message(decrypted)
+        else:
+            self._dispatch_data(bytes(decrypted.buffer))
+
+    async def _handle_encrypted_key_message(self, decrypted: Message) -> None:
+        """Handle the encrypted part of ECDH: PEER_PUBKEY and PUBKEY_ACCEPTED."""
+        decrypted.verify_checksum()
+        if decrypted.type == MessageType.PEER_PUBKEY:
+            self.logger.debug("Received peer public key, sending ours")
+            response = self._encryption.msg_peer_pubkey(decrypted)
+            await self._client.write_gatt_char(WRITE_UUID, response)
+        elif decrypted.type == MessageType.PUBKEY_ACCEPTED:
+            self.logger.debug("Key exchange complete, shared secret established")
+            self._encryption.msg_key_accepted(decrypted)
+            if self._handshake_complete is not None:
+                self._handshake_complete.set()
+
+    def _dispatch_data(self, data: bytes) -> None:
+        """Deliver a Modbus response to the active data callback."""
+        if self._data_callback is not None:
+            self._data_callback(data)
+        else:
+            self.logger.debug("Received data but no callback is registered")
+
+    async def _stop_notifications(self) -> None:
+        if self._client is not None:
+            try:
+                await self._client.stop_notify(NOTIFY_UUID)
+            except Exception:
+                pass
+
+    async def _disconnect_client(self) -> None:
+        if self._client is not None:
+            try:
+                await self._client.disconnect()
+            except Exception:
+                pass

--- a/bluetti_bt_lib/bluetooth/device_reader.py
+++ b/bluetti_bt_lib/bluetooth/device_reader.py
@@ -15,9 +15,10 @@ from ..utils.privacy import mac_loggable
 
 
 class DeviceReaderConfig:
-    def __init__(self, timeout: int = 60, use_encryption: bool = False) -> None:
+    def __init__(self, timeout: int = 60, use_encryption: bool = False, keep_alive_seconds: int = 0) -> None:
         self.timeout = timeout
         self.use_encryption = use_encryption
+        self.keep_alive_seconds = keep_alive_seconds
 
 
 class DeviceReader:
@@ -144,7 +145,8 @@ class DeviceReader:
                 return None
             finally:
                 if self.connection is not None:
-                    self._teardown_shared_connection()
+                    self.connection.clear_data_callback()
+                    asyncio.ensure_future(self._deferred_disconnect())
                 else:
                     await self._teardown_standalone_connection()
 
@@ -200,9 +202,11 @@ class DeviceReader:
             await asyncio.sleep(5)
             self.logger.debug("Encryption handshake not finished yet")
 
-    def _teardown_shared_connection(self) -> None:
-        """Release the data callback — connection stays open."""
-        self.connection.clear_data_callback()
+    async def _deferred_disconnect(self) -> None:
+        """Wait keep_alive_seconds, then disconnect to free the BLE slot."""
+        if self.config.keep_alive_seconds > 0:
+            await asyncio.sleep(self.config.keep_alive_seconds)
+        await self.connection.disconnect()
 
     async def _teardown_standalone_connection(self) -> None:
         """Stop notifications and disconnect own client."""

--- a/bluetti_bt_lib/bluetooth/device_reader.py
+++ b/bluetti_bt_lib/bluetooth/device_reader.py
@@ -6,6 +6,7 @@ from bleak import BleakClient, BleakScanner
 from bleak.exc import BleakError
 from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
 
+from .device_connection import DeviceConnection
 from .encryption import BluettiEncryption, Message, MessageType
 from ..base_devices import BluettiDevice
 from ..const import NOTIFY_UUID, WRITE_UUID
@@ -14,7 +15,7 @@ from ..utils.privacy import mac_loggable
 
 
 class DeviceReaderConfig:
-    def __init__(self, timeout: int = 60, use_encryption: bool = False):
+    def __init__(self, timeout: int = 60, use_encryption: bool = False) -> None:
         self.timeout = timeout
         self.use_encryption = use_encryption
 
@@ -28,15 +29,17 @@ class DeviceReader:
         config: DeviceReaderConfig = DeviceReaderConfig(),
         lock: asyncio.Lock = asyncio.Lock(),
         ble_client: BleakClient | None = None,
-    ):
+        connection: DeviceConnection | None = None,
+    ) -> None:
         self.mac = mac
         self.bluetti_device = bluetti_device
         self.create_future = future_builder_method
         self.config = config
         self.polling_lock = lock
+        self.connection = connection
 
         self.ble_client = ble_client
-        """Used for unittests"""
+        """Used for unit tests"""
 
         self.logger = logging.getLogger(
             f"{__name__}.{mac_loggable(mac).replace(':', '_')}"
@@ -69,47 +72,12 @@ class DeviceReader:
         async with self.polling_lock:
             try:
                 async with async_timeout.timeout(self.config.timeout):
-                    self.logger.debug("Searching for device")
-
-                    if self.ble_client:
-                        self.device = None
+                    if self.connection is not None:
+                        await self._connect_via_shared_connection()
                     else:
-                        self.device = await BleakScanner.find_device_by_address(
-                            self.mac, timeout=5
-                        )
-
-                        if self.device is None:
-                            self.logger.error("Device not found")
-                            return
-
-                    self.logger.debug("Connecting to device")
-
-                    if self.ble_client:
-                        self.client = self.ble_client
-                    else:
-                        self.client = await establish_connection(
-                            BleakClientWithServiceCache,
-                            self.device,
-                            self.device.name or "Unknown Device",
-                            max_attempts=10,
-                        )
-
-                    self.logger.debug("Connected to device")
-
-                    if not self.has_notifier:
-                        await self.client.start_notify(
-                            NOTIFY_UUID, self._notification_handler
-                        )
-                        self.has_notifier = True
+                        await self._connect_standalone()
 
                     self.logger.debug("Notification handler setup complete")
-
-                    while (
-                        self.config.use_encryption
-                        and not self.encryption.is_ready_for_commands
-                    ):
-                        await asyncio.sleep(5)
-                        self.logger.debug("Encryption handshake not finished yet")
 
                     for register in registers:
                         body = register.parse_response(
@@ -171,66 +139,121 @@ class DeviceReader:
             except BleakError as err:
                 self.logger.warning("Bleak error: %s", err)
                 return None
-            except BaseException as err:
+            except Exception as err:
                 self.logger.warning("Unknown error %s", err)
                 return None
             finally:
-                if self.has_notifier:
-                    try:
-                        await self.client.stop_notify(NOTIFY_UUID)
-                        self.logger.debug("Stopped notifier")
-                    except:
-                        # Ignore errors here
-                        pass
-                    self.has_notifier = False
-                if self.client:
-                    await self.client.disconnect()
-                    self.logger.debug("Disconnected from device")
+                if self.connection is not None:
+                    self._teardown_shared_connection()
+                else:
+                    await self._teardown_standalone_connection()
 
-            # Reset Encryption keys
-            self.encryption.reset()
+            if self.connection is None:
+                self.encryption.reset()
 
-            # Check if dict is empty
             if not parsed_data:
                 return None
 
             return parsed_data
 
+    async def _connect_via_shared_connection(self) -> None:
+        """Use an existing DeviceConnection instead of creating a new one."""
+        connected = await self.connection.ensure_connected()
+        if not connected:
+            raise BleakError("Could not connect to device via shared connection")
+        self.client = self.connection.client
+        self.connection.set_data_callback(self._on_data)
+        self.logger.debug("Using shared connection")
+
+    async def _connect_standalone(self) -> None:
+        """Scan, connect, and subscribe to notifications independently."""
+        self.logger.debug("Searching for device")
+
+        if self.ble_client:
+            self.device = None
+            self.client = self.ble_client
+        else:
+            self.device = await BleakScanner.find_device_by_address(
+                self.mac, timeout=5
+            )
+            if self.device is None:
+                self.logger.error("Device not found")
+                raise BleakError("Device not found")
+            self.logger.debug("Connecting to device")
+            self.client = await establish_connection(
+                BleakClientWithServiceCache,
+                self.device,
+                self.device.name or "Unknown Device",
+                max_attempts=10,
+            )
+
+        self.logger.debug("Connected to device")
+
+        if not self.has_notifier:
+            await self.client.start_notify(NOTIFY_UUID, self._notification_handler)
+            self.has_notifier = True
+
+        while (
+            self.config.use_encryption
+            and not self.encryption.is_ready_for_commands
+        ):
+            await asyncio.sleep(5)
+            self.logger.debug("Encryption handshake not finished yet")
+
+    def _teardown_shared_connection(self) -> None:
+        """Release the data callback — connection stays open."""
+        self.connection.clear_data_callback()
+
+    async def _teardown_standalone_connection(self) -> None:
+        """Stop notifications and disconnect own client."""
+        if self.has_notifier:
+            try:
+                await self.client.stop_notify(NOTIFY_UUID)
+                self.logger.debug("Stopped notifier")
+            except Exception:
+                pass
+            self.has_notifier = False
+        if self.client:
+            await self.client.disconnect()
+            self.logger.debug("Disconnected from device")
+
     async def _async_send_command(self, registers: DeviceRegister) -> bytes:
-        """Send command and return response"""
+        """Send a Modbus command and wait for the response."""
         self.current_registers = registers
         self.notify_response = bytearray()
         self.notify_future = self.create_future()
 
-        command_bytes = bytes(registers)
-
-        # Encrypt command
-        if self.config.use_encryption is True:
-            if not self.encryption.is_ready_for_commands:
-                return bytes()
-            command_bytes = self.encryption.aes_encrypt(
-                command_bytes, self.encryption.secure_aes_key, None
-            )
+        command_bytes = self._build_command_bytes(registers)
 
         try:
-            # Make request
             await self.client.write_gatt_char(WRITE_UUID, command_bytes)
-
             self.logger.debug("Request sent (%s)", registers)
-
-            # Wait for response
             res = await asyncio.wait_for(self.notify_future, timeout=5)
-
             self.logger.debug("Got response")
-
             return cast(bytes, res)
-        except:
+        except Exception:
             self.logger.warning("Error while reading data")
 
         return bytes()
 
-    async def _notification_handler(self, _: int, data: bytearray):
-        """Handle bt data."""
+    def _build_command_bytes(self, registers: DeviceRegister) -> bytes:
+        """Build and optionally encrypt the command bytes."""
+        command_bytes = bytes(registers)
+        if not self.config.use_encryption:
+            return command_bytes
+        enc = self.connection.encryption if self.connection is not None else self.encryption
+        if not enc.is_ready_for_commands:
+            return bytes()
+        return enc.aes_encrypt(command_bytes, enc.secure_aes_key, None)
+
+    def _on_data(self, data: bytes) -> None:
+        """Receive a decrypted Modbus response from the shared DeviceConnection."""
+        self.notify_response.extend(data)
+        if self.notify_future is not None:
+            self.notify_future.set_result(self.notify_response)
+
+    async def _notification_handler(self, _: int, data: bytearray) -> None:
+        """Handle BLE notifications in standalone (non-shared) mode."""
         self.logger.debug("Got new data")
 
         if self.config.use_encryption is True:
@@ -268,13 +291,7 @@ class DeviceReader:
                     self.encryption.msg_key_accepted(decrypted)
                     return
 
-            # Handle as message
+            # Handle as Modbus data response
             data = decrypted.buffer
 
-        # Save data
-        self.notify_response.extend(data)
-
-        if self.notify_future is None:
-            return
-
-        self.notify_future.set_result(self.notify_response)
+        self._on_data(bytes(data))

--- a/bluetti_bt_lib/bluetooth/device_writer.py
+++ b/bluetti_bt_lib/bluetooth/device_writer.py
@@ -80,16 +80,13 @@ class DeviceWriter:
 
     async def _complete_encryption_handshake(self):
         """Subscribe to BLE notifications and wait until ECDH key exchange is complete."""
+        self._handshake_complete = asyncio.Event()
         await self.client.start_notify(NOTIFY_UUID, self._on_encryption_message)
         self.logger.debug("Waiting for encryption handshake...")
-
-        elapsed = 0.0
-        while not self._encryption.is_ready_for_commands:
-            await asyncio.sleep(0.5)
-            elapsed += 0.5
-            if elapsed > 12:
-                raise TimeoutError("Encryption handshake timed out")
-
+        try:
+            await asyncio.wait_for(self._handshake_complete.wait(), timeout=12)
+        except asyncio.TimeoutError:
+            raise TimeoutError("Encryption handshake timed out")
         self.logger.debug("Encryption handshake complete")
 
     async def _cleanup(self):
@@ -142,3 +139,4 @@ class DeviceWriter:
         elif decrypted.type == MessageType.PUBKEY_ACCEPTED:
             self.logger.debug("Key exchange complete, shared secret established")
             self._encryption.msg_key_accepted(decrypted)
+            self._handshake_complete.set()

--- a/bluetti_bt_lib/bluetooth/device_writer.py
+++ b/bluetti_bt_lib/bluetooth/device_writer.py
@@ -1,13 +1,15 @@
 import asyncio
 import logging
 from typing import Any
+
 import async_timeout
 from bleak import BleakClient
 from bleak.exc import BleakError
 
-from ..const import WRITE_UUID
+from ..const import NOTIFY_UUID, WRITE_UUID
 from ..base_devices import BluettiDevice
 from ..utils.privacy import mac_loggable
+from .encryption import BluettiEncryption, Message, MessageType
 
 
 class DeviceWriterConfig:
@@ -28,56 +30,115 @@ class DeviceWriter:
         self.bluetti_device = bluetti_device
         self.config = config
         self.polling_lock = lock
-
+        self._encryption = BluettiEncryption()
         self.logger = logging.getLogger(
             f"{__name__}.{mac_loggable(bleak_client.address).replace(':', '_')}"
         )
 
     async def write(self, field: str, value: Any):
-        if self.config.use_encryption:
-            self.logger.error("Encryption on writes is not yet supported")
-            return
-
-        available_fields = [f.name for f in self.bluetti_device.fields]
-        if field not in available_fields:
-            self.logger.error("Field not supported")
-            return
-
-        command = self.bluetti_device.build_write_command(field, value)
-
+        command = self._build_write_command(field, value)
         if command is None:
-            self.logger.error("Field is not writeable")
             return
-
-        self.logger.debug("Writing to device register")
 
         async with self.polling_lock:
             try:
                 async with async_timeout.timeout(self.config.timeout):
-                    if not self.client.is_connected:
-                        self.logger.debug("Connecting to device")
-                        await self.client.connect()
-
-                    self.logger.debug("Connected to device")
-
-                    self.logger.debug("Writing command: %s", command)
-
-                    await self.client.write_gatt_char(
-                        WRITE_UUID,
-                        bytes(command),
-                    )
-
+                    await self._connect_if_needed()
+                    command_bytes = await self._prepare_command_bytes(bytes(command))
+                    await self.client.write_gatt_char(WRITE_UUID, command_bytes)
                     self.logger.debug("Write successful")
-
             except TimeoutError:
-                self.logger.warning("Timeout")
-                return None
+                self.logger.warning("Timeout writing to device")
             except BleakError as err:
                 self.logger.warning("Bleak error: %s", err)
-                return None
-            except BaseException as err:
+            except Exception as err:
                 self.logger.warning("Unknown error: %s", err)
-                return None
             finally:
-                await self.client.disconnect()
-                self.logger.debug("Disconnected from device")
+                await self._cleanup()
+
+    def _build_write_command(self, field: str, value: Any):
+        """Validate field and build the Modbus write command. Returns None if invalid."""
+        if field not in [f.name for f in self.bluetti_device.fields]:
+            self.logger.error("Field not supported: %s", field)
+            return None
+        command = self.bluetti_device.build_write_command(field, value)
+        if command is None:
+            self.logger.error("Field is not writeable: %s", field)
+        return command
+
+    async def _connect_if_needed(self):
+        if not self.client.is_connected:
+            self.logger.debug("Connecting to device")
+            await self.client.connect()
+
+    async def _prepare_command_bytes(self, raw_bytes: bytes) -> bytes:
+        """Return command bytes ready to send: plain bytes or AES-encrypted after handshake."""
+        if not self.config.use_encryption:
+            return raw_bytes
+        await self._complete_encryption_handshake()
+        return self._encryption.aes_encrypt(raw_bytes, self._encryption.secure_aes_key, None)
+
+    async def _complete_encryption_handshake(self):
+        """Subscribe to BLE notifications and wait until ECDH key exchange is complete."""
+        await self.client.start_notify(NOTIFY_UUID, self._on_encryption_message)
+        self.logger.debug("Waiting for encryption handshake...")
+
+        elapsed = 0.0
+        while not self._encryption.is_ready_for_commands:
+            await asyncio.sleep(0.5)
+            elapsed += 0.5
+            if elapsed > 12:
+                raise TimeoutError("Encryption handshake timed out")
+
+        self.logger.debug("Encryption handshake complete")
+
+    async def _cleanup(self):
+        if self.config.use_encryption:
+            try:
+                await self.client.stop_notify(NOTIFY_UUID)
+            except Exception:
+                pass
+            self._encryption.reset()
+        try:
+            await self.client.disconnect()
+        except Exception:
+            pass
+
+    async def _on_encryption_message(self, _sender: int, data: bytearray):
+        """Dispatch each BLE notification to the appropriate handshake handler."""
+        message = Message(data)
+        if message.is_pre_key_exchange:
+            await self._handle_pre_key_message(message)
+        else:
+            await self._handle_encrypted_handshake_message(message)
+
+    async def _handle_pre_key_message(self, message: Message):
+        """Handle unencrypted handshake messages: challenge and challenge-accepted."""
+        message.verify_checksum()
+        if message.type == MessageType.CHALLENGE:
+            self.logger.debug("Received challenge, sending response")
+            response = self._encryption.msg_challenge(message)
+            await self.client.write_gatt_char(WRITE_UUID, response)
+        elif message.type == MessageType.CHALLENGE_ACCEPTED:
+            self.logger.debug("Challenge accepted, starting key exchange")
+
+    async def _handle_encrypted_handshake_message(self, message: Message):
+        """Handle encrypted handshake messages: peer public key and key-accepted."""
+        if self._encryption.unsecure_aes_key is None:
+            self.logger.warning("Received encrypted message before challenge was completed")
+            return
+
+        key, iv = self._encryption.getKeyIv()
+        decrypted = Message(self._encryption.aes_decrypt(message.buffer, key, iv))
+
+        if not decrypted.is_pre_key_exchange:
+            return
+
+        decrypted.verify_checksum()
+        if decrypted.type == MessageType.PEER_PUBKEY:
+            self.logger.debug("Received peer public key, sending ours")
+            response = self._encryption.msg_peer_pubkey(decrypted)
+            await self.client.write_gatt_char(WRITE_UUID, response)
+        elif decrypted.type == MessageType.PUBKEY_ACCEPTED:
+            self.logger.debug("Key exchange complete, shared secret established")
+            self._encryption.msg_key_accepted(decrypted)

--- a/bluetti_bt_lib/bluetooth/device_writer.py
+++ b/bluetti_bt_lib/bluetooth/device_writer.py
@@ -9,11 +9,12 @@ from bleak.exc import BleakError
 from ..const import NOTIFY_UUID, WRITE_UUID
 from ..base_devices import BluettiDevice
 from ..utils.privacy import mac_loggable
+from .device_connection import DeviceConnection
 from .encryption import BluettiEncryption, Message, MessageType
 
 
 class DeviceWriterConfig:
-    def __init__(self, timeout: int = 15, use_encryption: bool = False):
+    def __init__(self, timeout: int = 15, use_encryption: bool = False) -> None:
         self.timeout = timeout
         self.use_encryption = use_encryption
 
@@ -21,21 +22,26 @@ class DeviceWriterConfig:
 class DeviceWriter:
     def __init__(
         self,
-        bleak_client: BleakClient,
+        bleak_client: BleakClient | None,
         bluetti_device: BluettiDevice,
         config: DeviceWriterConfig = DeviceWriterConfig(),
         lock: asyncio.Lock = asyncio.Lock(),
-    ):
+        connection: DeviceConnection | None = None,
+    ) -> None:
         self.client = bleak_client
         self.bluetti_device = bluetti_device
         self.config = config
         self.polling_lock = lock
+        self.connection = connection
         self._encryption = BluettiEncryption()
+        self._handshake_complete: asyncio.Event | None = None
+
+        address = connection.address if bleak_client is None else bleak_client.address
         self.logger = logging.getLogger(
-            f"{__name__}.{mac_loggable(bleak_client.address).replace(':', '_')}"
+            f"{__name__}.{mac_loggable(address).replace(':', '_')}"
         )
 
-    async def write(self, field: str, value: Any):
+    async def write(self, field: str, value: Any) -> None:
         command = self._build_write_command(field, value)
         if command is None:
             return
@@ -45,7 +51,7 @@ class DeviceWriter:
                 async with async_timeout.timeout(self.config.timeout):
                     await self._connect_if_needed()
                     command_bytes = await self._prepare_command_bytes(bytes(command))
-                    await self.client.write_gatt_char(WRITE_UUID, command_bytes)
+                    await self._active_client().write_gatt_char(WRITE_UUID, command_bytes)
                     self.logger.debug("Write successful")
             except TimeoutError:
                 self.logger.warning("Timeout writing to device")
@@ -56,7 +62,7 @@ class DeviceWriter:
             finally:
                 await self._cleanup()
 
-    def _build_write_command(self, field: str, value: Any):
+    def _build_write_command(self, field: str, value: Any) -> Any:
         """Validate field and build the Modbus write command. Returns None if invalid."""
         if field not in [f.name for f in self.bluetti_device.fields]:
             self.logger.error("Field not supported: %s", field)
@@ -66,30 +72,55 @@ class DeviceWriter:
             self.logger.error("Field is not writeable: %s", field)
         return command
 
-    async def _connect_if_needed(self):
-        if not self.client.is_connected:
+    def _active_client(self) -> BleakClient | None:
+        """Return the BleakClient to use — shared connection or own client."""
+        if self.connection is not None:
+            return self.connection.client
+        return self.client
+
+    async def _connect_if_needed(self) -> None:
+        if self.connection is not None:
+            await self.connection.ensure_connected()
+        elif not self.client.is_connected:
             self.logger.debug("Connecting to device")
             await self.client.connect()
 
     async def _prepare_command_bytes(self, raw_bytes: bytes) -> bytes:
-        """Return command bytes ready to send: plain bytes or AES-encrypted after handshake."""
+        """Return command bytes ready to send: plain or AES-encrypted."""
         if not self.config.use_encryption:
             return raw_bytes
+        if self.connection is not None:
+            return self._encrypt_with_shared_session(raw_bytes)
         await self._complete_encryption_handshake()
-        return self._encryption.aes_encrypt(raw_bytes, self._encryption.secure_aes_key, None)
+        return self._encrypt_with_own_session(raw_bytes)
 
-    async def _complete_encryption_handshake(self):
+    def _encrypt_with_shared_session(self, data: bytes) -> bytes:
+        """Encrypt using the session key already established by DeviceConnection."""
+        enc = self.connection.encryption
+        return enc.aes_encrypt(data, enc.secure_aes_key, None)
+
+    def _encrypt_with_own_session(self, data: bytes) -> bytes:
+        """Encrypt using the session key established by this writer's own handshake."""
+        return self._encryption.aes_encrypt(data, self._encryption.secure_aes_key, None)
+
+    async def _complete_encryption_handshake(self) -> None:
         """Subscribe to BLE notifications and wait until ECDH key exchange is complete."""
         self._handshake_complete = asyncio.Event()
         await self.client.start_notify(NOTIFY_UUID, self._on_encryption_message)
-        self.logger.debug("Waiting for encryption handshake...")
+        self.logger.debug("Waiting for encryption handshake")
         try:
             await asyncio.wait_for(self._handshake_complete.wait(), timeout=12)
         except asyncio.TimeoutError:
             raise TimeoutError("Encryption handshake timed out")
         self.logger.debug("Encryption handshake complete")
 
-    async def _cleanup(self):
+    async def _cleanup(self) -> None:
+        if self.connection is not None:
+            return  # Shared connection outlives this write — do not touch it
+        await self._teardown_own_connection()
+
+    async def _teardown_own_connection(self) -> None:
+        """Stop notifications, reset encryption, and disconnect own client."""
         if self.config.use_encryption:
             try:
                 await self.client.stop_notify(NOTIFY_UUID)
@@ -101,7 +132,7 @@ class DeviceWriter:
         except Exception:
             pass
 
-    async def _on_encryption_message(self, _sender: int, data: bytearray):
+    async def _on_encryption_message(self, _sender: int, data: bytearray) -> None:
         """Dispatch each BLE notification to the appropriate handshake handler."""
         message = Message(data)
         if message.is_pre_key_exchange:
@@ -109,7 +140,7 @@ class DeviceWriter:
         else:
             await self._handle_encrypted_handshake_message(message)
 
-    async def _handle_pre_key_message(self, message: Message):
+    async def _handle_pre_key_message(self, message: Message) -> None:
         """Handle unencrypted handshake messages: challenge and challenge-accepted."""
         message.verify_checksum()
         if message.type == MessageType.CHALLENGE:
@@ -119,7 +150,7 @@ class DeviceWriter:
         elif message.type == MessageType.CHALLENGE_ACCEPTED:
             self.logger.debug("Challenge accepted, starting key exchange")
 
-    async def _handle_encrypted_handshake_message(self, message: Message):
+    async def _handle_encrypted_handshake_message(self, message: Message) -> None:
         """Handle encrypted handshake messages: peer public key and key-accepted."""
         if self._encryption.unsecure_aes_key is None:
             self.logger.warning("Received encrypted message before challenge was completed")

--- a/bluetti_bt_lib/scripts/bluetti_write.py
+++ b/bluetti_bt_lib/scripts/bluetti_write.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 from bleak import BleakClient
 
-from ..bluetooth import DeviceWriter
+from ..bluetooth import DeviceWriter, DeviceWriterConfig
 from ..utils.device_builder import build_device
 
 
@@ -20,15 +20,12 @@ async def async_write(
         print("Unsupported powerstation type")
         return
 
-    if encryption:
-        print("Encryption is not supported")
-        return
-
     print("Client created")
 
     writer = DeviceWriter(
         client,
         built,
+        config=DeviceWriterConfig(use_encryption=encryption or False),
     )
 
     print("Writer created")

--- a/tests/bluetooth/test_device_connection.py
+++ b/tests/bluetooth/test_device_connection.py
@@ -1,0 +1,117 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from bluetti_bt_lib.bluetooth.device_connection import DeviceConnection
+
+
+class MockClient:
+    is_connected = True
+
+
+class TestDeviceConnectionCallbacks(unittest.TestCase):
+    def _conn(self) -> DeviceConnection:
+        return DeviceConnection("AA:BB:CC:DD:EE:FF")
+
+    def test_dispatch_data_calls_registered_callback(self):
+        conn = self._conn()
+        received = []
+        conn.set_data_callback(received.append)
+        conn._dispatch_data(b"\x01\x02")
+        self.assertEqual(received, [b"\x01\x02"])
+
+    def test_dispatch_data_without_callback_does_not_raise(self):
+        conn = self._conn()
+        conn._dispatch_data(b"\x01\x02")
+
+    def test_clear_data_callback_stops_dispatch(self):
+        conn = self._conn()
+        received = []
+        conn.set_data_callback(received.append)
+        conn.clear_data_callback()
+        conn._dispatch_data(b"\x01\x02")
+        self.assertEqual(received, [])
+
+    def test_replacing_callback_dispatches_to_new_one_only(self):
+        conn = self._conn()
+        first, second = [], []
+        conn.set_data_callback(first.append)
+        conn.set_data_callback(second.append)
+        conn._dispatch_data(b"\xff")
+        self.assertEqual(first, [])
+        self.assertEqual(second, [b"\xff"])
+
+    def test_dispatch_delivers_exact_bytes(self):
+        conn = self._conn()
+        received = []
+        conn.set_data_callback(received.append)
+        payload = bytes(range(20))
+        conn._dispatch_data(payload)
+        self.assertEqual(received[0], payload)
+
+
+class TestDeviceConnectionIsConnected(unittest.TestCase):
+    def test_is_connected_false_when_no_client(self):
+        conn = DeviceConnection("AA:BB:CC:DD:EE:FF")
+        self.assertFalse(conn.is_connected)
+
+    def test_is_connected_true_when_client_connected(self):
+        conn = DeviceConnection("AA:BB:CC:DD:EE:FF")
+        conn._client = MockClient()
+        self.assertTrue(conn.is_connected)
+
+    def test_is_connected_false_when_client_reports_disconnected(self):
+        conn = DeviceConnection("AA:BB:CC:DD:EE:FF")
+        client = MockClient()
+        client.is_connected = False
+        conn._client = client
+        self.assertFalse(conn.is_connected)
+
+    def test_address_property_returns_address(self):
+        conn = DeviceConnection("AA:BB:CC:DD:EE:FF")
+        self.assertEqual(conn.address, "AA:BB:CC:DD:EE:FF")
+
+
+class TestDeviceConnectionDisconnect(unittest.IsolatedAsyncioTestCase):
+    async def test_disconnect_sets_client_to_none(self):
+        conn = DeviceConnection("AA:BB:CC:DD:EE:FF")
+        conn._client = MockClient()
+        conn._client.stop_notify = AsyncMock()
+        conn._client.disconnect = AsyncMock()
+        await conn.disconnect()
+        self.assertIsNone(conn._client)
+
+    async def test_disconnect_resets_encryption(self):
+        conn = DeviceConnection("AA:BB:CC:DD:EE:FF")
+        conn._client = MockClient()
+        conn._client.stop_notify = AsyncMock()
+        conn._client.disconnect = AsyncMock()
+        conn._encryption.reset = MagicMock()
+        await conn.disconnect()
+        conn._encryption.reset.assert_called_once()
+
+    async def test_disconnect_when_no_client_does_not_raise(self):
+        conn = DeviceConnection("AA:BB:CC:DD:EE:FF")
+        await conn.disconnect()  # should not raise
+
+
+class TestDeviceConnectionEnsureConnected(unittest.IsolatedAsyncioTestCase):
+    async def test_ensure_connected_skips_connect_when_already_connected(self):
+        conn = DeviceConnection("AA:BB:CC:DD:EE:FF")
+        conn._client = MockClient()
+        conn.connect = AsyncMock(side_effect=AssertionError("should not reconnect"))
+        result = await conn.ensure_connected()
+        self.assertTrue(result)
+
+    async def test_ensure_connected_calls_connect_when_disconnected(self):
+        conn = DeviceConnection("AA:BB:CC:DD:EE:FF")
+        conn.connect = AsyncMock(return_value=True)
+        result = await conn.ensure_connected()
+        conn.connect.assert_called_once()
+        self.assertTrue(result)
+
+    async def test_ensure_connected_returns_false_when_connect_fails(self):
+        conn = DeviceConnection("AA:BB:CC:DD:EE:FF")
+        conn.connect = AsyncMock(return_value=False)
+        result = await conn.ensure_connected()
+        self.assertFalse(result)

--- a/tests/bluetooth/test_device_reader_shared_connection.py
+++ b/tests/bluetooth/test_device_reader_shared_connection.py
@@ -1,0 +1,157 @@
+import asyncio
+import struct
+import unittest
+from unittest.mock import AsyncMock
+
+from bluetti_bt_lib.devices.ac180p import AC180P
+from bluetti_bt_lib.bluetooth.device_reader import DeviceReader
+from bluetti_bt_lib.fields import FieldName
+from bluetti_bt_lib.utils.bleak_client_mock import ClientMockNoEncryption
+
+
+class MockClientForSharedConnection(ClientMockNoEncryption):
+    """Mock client that routes write responses directly to the DeviceConnection callback.
+
+    In real BLE: write_gatt_char → notification → DeviceConnection._on_notification
+                 → _dispatch_data → _data_callback (reader._on_data)
+    Here we skip the notification layer since DeviceConnection is mocked out.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._data_callback = None
+
+    async def write_gatt_char(self, char_specifier, data, response=None):
+        cmd = struct.unpack_from("!HHHH", data)
+        content = bytes(await self._get_register(cmd[1], cmd[2]))
+        if self._data_callback is not None:
+            self._data_callback(content)
+
+
+class MockDeviceConnection:
+    """Minimal DeviceConnection mock: wires reader's data callback to the mock client."""
+
+    def __init__(self, client: MockClientForSharedConnection):
+        self._client = client
+
+    @property
+    def client(self):
+        return self._client
+
+    @property
+    def encryption(self):
+        from bluetti_bt_lib.bluetooth.encryption import BluettiEncryption
+        return BluettiEncryption()
+
+    @property
+    def is_connected(self):
+        return True
+
+    async def ensure_connected(self) -> bool:
+        await asyncio.sleep(0)
+        return True
+
+    async def disconnect(self) -> None:
+        await asyncio.sleep(0)  # mock — disconnect policy is tested separately
+
+    def set_data_callback(self, callback):
+        self._client._data_callback = callback
+
+    def clear_data_callback(self):
+        self._client._data_callback = None
+
+
+class MockDeviceConnectionFailsToConnect(MockDeviceConnection):
+    async def ensure_connected(self) -> bool:
+        await asyncio.sleep(0)
+        return False
+
+
+def make_ac180p_client() -> MockClientForSharedConnection:
+    client = MockClientForSharedConnection()
+    client.add_r_int(142, 350)   # AC_OUTPUT_POWER
+    client.add_r_int(140, 12)    # DC_OUTPUT_POWER
+    client.add_r_int(144, 0)     # DC_INPUT_POWER
+    client.add_r_int(146, 362)   # AC_INPUT_POWER
+    client.add_r_int(1314, 2300) # AC_INPUT_VOLTAGE (DecimalField, divisor=1)
+    return client
+
+
+class TestDeviceReaderSharedConnectionNonEncrypted(unittest.IsolatedAsyncioTestCase):
+    async def test_read_returns_ac180p_sensor_data(self):
+        client = make_ac180p_client()
+        connection = MockDeviceConnection(client)
+
+        reader = DeviceReader(
+            "AA:BB:CC:DD:EE:FF",
+            AC180P(),
+            asyncio.Future,
+            connection=connection,
+        )
+
+        data = await reader.read()
+
+        self.assertIsNotNone(data)
+        self.assertEqual(data.get(FieldName.AC_OUTPUT_POWER.value), 350)
+        self.assertEqual(data.get(FieldName.DC_OUTPUT_POWER.value), 12)
+        self.assertEqual(data.get(FieldName.AC_INPUT_POWER.value), 362)
+
+    async def test_read_clears_data_callback_after_read(self):
+        client = make_ac180p_client()
+        connection = MockDeviceConnection(client)
+
+        reader = DeviceReader(
+            "AA:BB:CC:DD:EE:FF",
+            AC180P(),
+            asyncio.Future,
+            connection=connection,
+        )
+
+        await reader.read()
+
+        self.assertIsNone(client._data_callback)
+
+    async def test_read_returns_none_when_connection_fails(self):
+        client = make_ac180p_client()
+        connection = MockDeviceConnectionFailsToConnect(client)
+
+        reader = DeviceReader(
+            "AA:BB:CC:DD:EE:FF",
+            AC180P(),
+            asyncio.Future,
+            connection=connection,
+        )
+
+        data = await reader.read()
+        self.assertIsNone(data)
+
+    async def test_multiple_reads_reuse_connection(self):
+        client = make_ac180p_client()
+        connection = MockDeviceConnection(client)
+        connection.ensure_connected = AsyncMock(return_value=True)
+        connection.disconnect = AsyncMock()
+
+        reader = DeviceReader(
+            "AA:BB:CC:DD:EE:FF",
+            AC180P(),
+            asyncio.Future,
+            connection=connection,
+        )
+
+        await reader.read()
+        await reader.read()
+
+        self.assertEqual(connection.ensure_connected.call_count, 2)
+
+    def test_callback_is_none_before_first_read(self):
+        client = make_ac180p_client()
+        connection = MockDeviceConnection(client)
+
+        DeviceReader(
+            "AA:BB:CC:DD:EE:FF",
+            AC180P(),
+            asyncio.Future,
+            connection=connection,
+        )
+
+        self.assertIsNone(client._data_callback)

--- a/tests/bluetooth/test_device_writer_shared_connection.py
+++ b/tests/bluetooth/test_device_writer_shared_connection.py
@@ -1,0 +1,142 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from bluetti_bt_lib.devices.ac180p import AC180P
+from bluetti_bt_lib.bluetooth.device_writer import DeviceWriter, DeviceWriterConfig
+from bluetti_bt_lib.fields import FieldName
+from bluetti_bt_lib.enums import ChargingMode
+
+
+class MockClientForWrite:
+    """Mock BleakClient that records write_gatt_char calls without processing them."""
+
+    is_connected = True
+
+    def __init__(self):
+        self.written_data = []
+
+    async def write_gatt_char(self, char_specifier, data, response=None):
+        await asyncio.sleep(0)
+        self.written_data.append(bytes(data))
+
+    async def start_notify(self, char_specifier, callback, **kwargs):
+        await asyncio.sleep(0)  # not needed — writer uses shared connection, no own notify subscription
+
+    async def stop_notify(self, char_specifier):
+        await asyncio.sleep(0)  # not needed — writer uses shared connection, no own notify subscription
+
+    async def disconnect(self):
+        await asyncio.sleep(0)  # not needed — mock, connection lifecycle managed by DeviceConnection
+
+
+class MockDeviceConnection:
+    def __init__(self, client: MockClientForWrite):
+        self._client = client
+        self._encryption = MagicMock()
+
+    @property
+    def client(self):
+        return self._client
+
+    @property
+    def encryption(self):
+        return self._encryption
+
+    @property
+    def address(self):
+        return "AA:BB:CC:DD:EE:FF"
+
+    @property
+    def is_connected(self):
+        return True
+
+    async def ensure_connected(self) -> bool:
+        await asyncio.sleep(0)
+        return True
+
+    async def disconnect(self) -> None:
+        await asyncio.sleep(0)  # mock — disconnect policy is tested separately
+
+
+class MockDeviceConnectionFailsToConnect(MockDeviceConnection):
+    async def ensure_connected(self) -> bool:
+        await asyncio.sleep(0)
+        return False
+
+
+class TestDeviceWriterSharedConnectionNonEncrypted(unittest.IsolatedAsyncioTestCase):
+    def _make_writer(self, connection) -> DeviceWriter:
+        return DeviceWriter(
+            bleak_client=None,
+            bluetti_device=AC180P(),
+            config=DeviceWriterConfig(timeout=5, use_encryption=False),
+            lock=asyncio.Lock(),
+            connection=connection,
+        )
+
+    async def test_write_switch_field_sends_command(self):
+        client = MockClientForWrite()
+        connection = MockDeviceConnection(client)
+        writer = self._make_writer(connection)
+
+        await writer.write(FieldName.CTRL_AC.value, True)
+
+        self.assertEqual(len(client.written_data), 1)
+
+    async def test_write_switch_field_off_sends_command(self):
+        client = MockClientForWrite()
+        connection = MockDeviceConnection(client)
+        writer = self._make_writer(connection)
+
+        await writer.write(FieldName.CTRL_AC.value, False)
+
+        self.assertEqual(len(client.written_data), 1)
+
+    async def test_write_select_field_sends_command(self):
+        client = MockClientForWrite()
+        connection = MockDeviceConnection(client)
+        writer = self._make_writer(connection)
+
+        await writer.write(FieldName.CTRL_CHARGING_MODE.value, ChargingMode.STANDARD.name)
+
+        self.assertEqual(len(client.written_data), 1)
+
+    async def test_write_unknown_field_sends_nothing(self):
+        client = MockClientForWrite()
+        connection = MockDeviceConnection(client)
+        writer = self._make_writer(connection)
+
+        await writer.write("nonexistent_field", True)
+
+        self.assertEqual(len(client.written_data), 0)
+
+    async def test_write_read_only_field_sends_nothing(self):
+        client = MockClientForWrite()
+        connection = MockDeviceConnection(client)
+        writer = self._make_writer(connection)
+
+        # AC_OUTPUT_POWER is UIntField (read-only)
+        await writer.write(FieldName.AC_OUTPUT_POWER.value, 100)
+
+        self.assertEqual(len(client.written_data), 0)
+
+    async def test_write_does_not_disconnect_shared_connection(self):
+        client = MockClientForWrite()
+        connection = MockDeviceConnection(client)
+        connection.disconnect = AsyncMock()
+        writer = self._make_writer(connection)
+
+        await writer.write(FieldName.CTRL_AC.value, True)
+
+        connection.disconnect.assert_not_called()
+
+    async def test_write_calls_ensure_connected(self):
+        client = MockClientForWrite()
+        connection = MockDeviceConnection(client)
+        connection.ensure_connected = AsyncMock(return_value=True)
+        writer = self._make_writer(connection)
+
+        await writer.write(FieldName.CTRL_AC.value, True)
+
+        connection.ensure_connected.assert_called_once()


### PR DESCRIPTION
## Problem

Building on #59, I tested switches and selects on my AC180P. The feature worked, but every toggle took **5–14 seconds**:

| Step | Time |
|------|------|
| `establish_connection` | 0–9 s (unpredictable, main bottleneck) |
| ECDH handshake | ~1.3 s |
| GATT write | ~0.03 s |
| Disconnect | ~2.25 s |
| `asyncio.sleep(2)` | 2 s |

The root cause: `DeviceWriter` opened a fresh BLE connection and ran the full ECDH handshake for every single write command, then disconnected.

Holding the connection open was the obvious fix — but it revealed a second problem: the device supports only one BLE connection at a time, so the official Bluetti app could not connect while Home Assistant held the link.

## What changed

### `bluetti_bt_lib/bluetooth/device_connection.py` *(new)*

A new `DeviceConnection` class that owns a single `BleakClient` and a `BluettiEncryption` session shared between `DeviceReader` and `DeviceWriter`.

The connection lifecycle:

1. `connect()` — scans for the device, establishes the BLE link
2. Subscribe to NOTIFY_UUID with a single shared handler
3. Perform ECDH handshake (CHALLENGE → CHALLENGE_ACCEPTED → PEER_PUBKEY → PUBKEY_ACCEPTED); completion signaled via `asyncio.Event`
4. `connect()` returns `True` — reader/writer can now use the shared session
5. `disconnect()` — unsubscribes, resets encryption state, closes the link

The single notification handler routes messages internally:

| Message type | Handled by |
|---|---|
| CHALLENGE, CHALLENGE_ACCEPTED | `_handle_pre_key_message()` (during `connect()`) |
| PEER_PUBKEY, PUBKEY_ACCEPTED | `_handle_encrypted_key_message()` (during `connect()`) |
| Modbus responses | `_dispatch_data()` → forwarded via `set_data_callback()` |

### `bluetti_bt_lib/bluetooth/device_writer.py`

Added `connection: DeviceConnection | None = None` parameter. When provided, the writer skips `establish_connection`, skips the ECDH handshake (already done), uses `connection.encryption` for AES encryption, and does **not** disconnect on cleanup — the shared connection stays alive.

When `connection=None` the behaviour is identical to before.

### `bluetti_bt_lib/bluetooth/device_reader.py`

Added `connection: DeviceConnection | None = None` parameter. When provided:

- Uses the shared `BleakClient` instead of opening its own
- Registers a data callback via `connection.set_data_callback()` instead of subscribing to NOTIFY_UUID
- Skips the handshake wait (already complete)
- After each read cycle, clears the data callback and schedules a deferred disconnect using `keep_alive_seconds` from `DeviceReaderConfig` (default `0`). This keeps the BLE session alive briefly so writes arriving within that window are instant, then frees the slot so the original Bluetti app can connect

When `connection=None` the behaviour is identical to before.

### `bluetti_bt_lib/__init__.py` / `bluetti_bt_lib/bluetooth/__init__.py`

Added `DeviceConnection` to the top-level package exports.

## Write latency after this change

| Scenario | Time |
|----------|------|
| Write within keep_alive window | ~0.03 s |
| First write (fresh connection) | ~1.3 s |
| After connection drop (reconnect) | ~1.3 s |

## Tested on

Bluetti AC180P via ESPHome BLE proxy
AC output, DC output, Power Lifting, Charging Mode — all confirmed working

The HA integration side (coordinator wiring, shared lock, write_pending guard, deferred disconnect) is in a test branch:
[defire04/hassio-bluetti-bt @ test-encrypted-writes-and-persistent-ble-connection](https://github.com/defire04/hassio-bluetti-bt/tree/test-encrypted-writes-and-persistent-ble-connection)

## Notes

This PR builds on #59 — the encryption handshake implementation there is unchanged; `DeviceConnection` reuses it and lifts it out of `DeviceWriter` so both reader and writer can share the session.