### PR TITLE
AP300: full device model with sensors, controls, NumberField

### DIFF
--- a/bluetti_bt_lib/__init__.py
+++ b/bluetti_bt_lib/__init__.py
@@ -9,5 +9,5 @@ from .bluetooth import (
     recognize_device,
 )
 from .enums import *
-from .fields import DeviceField, FieldName, FieldUnit, get_unit
+from .fields import DeviceField, NumberField, FieldName, FieldUnit, get_unit
 from .utils.device_builder import build_device

--- a/bluetti_bt_lib/base_devices/bluetti_device.py
+++ b/bluetti_bt_lib/base_devices/bluetti_device.py
@@ -1,7 +1,7 @@
 from typing import Any, List
 
 from ..registers import ReadableRegisters, WriteableRegister
-from ..fields import DeviceField, BoolField, BoolFieldNonZero, SwitchField, SelectField
+from ..fields import DeviceField, BoolField, BoolFieldNonZero, SwitchField, SelectField, NumberField
 
 
 class BluettiDevice:
@@ -111,6 +111,8 @@ class BluettiDevice:
                 value = field.e[value].value
         elif isinstance(field, SwitchField):
             value = 1 if value else 0
+        elif isinstance(field, NumberField):
+            value = int(value)
 
         return WriteableRegister(field.address, value)
 
@@ -131,6 +133,10 @@ class BluettiDevice:
         """Returns all select fields for this device"""
         return [f for f in self.fields if isinstance(f, SelectField)]
 
+    def get_number_fields(self):
+        """Returns all number (slider) fields for this device"""
+        return [f for f in self.fields if isinstance(f, NumberField)]
+
     def get_sensor_fields(self):
         """Returns all sensor fields for this device"""
         return [
@@ -140,4 +146,5 @@ class BluettiDevice:
             and not isinstance(f, BoolFieldNonZero)
             and not isinstance(f, SwitchField)
             and not isinstance(f, SelectField)
+            and not isinstance(f, NumberField)
         ]

--- a/bluetti_bt_lib/devices/ap300.py
+++ b/bluetti_bt_lib/devices/ap300.py
@@ -1,15 +1,39 @@
 from ..base_devices import BaseDeviceV2
-from ..fields import FieldName, UIntField, DecimalField
+from ..enums import ChargingMode, DisplayMode, WorkingMode
+from ..fields import (
+    FieldName,
+    UIntField,
+    NumberField,
+    DecimalField,
+    SwitchField,
+    SelectField,
+)
 
 
 class AP300(BaseDeviceV2):
     def __init__(self):
         super().__init__(
             [
+                DecimalField(FieldName.TIME_REMAINING, 104, 1),
                 UIntField(FieldName.DC_OUTPUT_POWER, 140),
                 UIntField(FieldName.AC_OUTPUT_POWER, 142),
                 UIntField(FieldName.DC_INPUT_POWER, 144),
                 UIntField(FieldName.AC_INPUT_POWER, 146),
+                DecimalField(FieldName.AC_INPUT_FREQUENCY, 1300, 1),
                 DecimalField(FieldName.AC_INPUT_VOLTAGE, 1314, 1),
+                DecimalField(FieldName.AC_INPUT_CURRENT, 1315, 1),
+                DecimalField(FieldName.AC_OUTPUT_FREQUENCY, 1500, 1),
+                DecimalField(FieldName.AC_OUTPUT_VOLTAGE, 1511, 1),
+                SwitchField(FieldName.CTRL_AC, 2011),
+                SwitchField(FieldName.CTRL_DC, 2012),
+                SwitchField(FieldName.CTRL_ECO_DC, 2014),
+                SwitchField(FieldName.CTRL_ECO_AC, 2017),
+                SelectField(FieldName.CTRL_CHARGING_MODE, 2020, ChargingMode),
+                SwitchField(FieldName.CTRL_POWER_LIFTING, 2021),
+                NumberField(FieldName.BATTERY_SOC_RANGE_START, 2022, min=0, max=100),
+                NumberField(FieldName.BATTERY_SOC_RANGE_END, 2023, min=0, max=100),
+                SelectField(FieldName.CTRL_WORKING_MODE, 2005, WorkingMode),
+                SwitchField(FieldName.CTRL_CHARGE_FROM_GRID, 2207),
+                SelectField(FieldName.CTRL_DISPLAY_TIMEOUT, 2067, DisplayMode),
             ],
         )

--- a/bluetti_bt_lib/enums/__init__.py
+++ b/bluetti_bt_lib/enums/__init__.py
@@ -5,3 +5,4 @@ from .led_mode import *
 from .output_mode import *
 from .split_phase_mode import *
 from .ups_mode import *
+from .working_mode import *

--- a/bluetti_bt_lib/enums/working_mode.py
+++ b/bluetti_bt_lib/enums/working_mode.py
@@ -1,0 +1,9 @@
+from enum import Enum, unique
+
+
+@unique
+class WorkingMode(Enum):
+    CUSTOM = 1
+    SELF_CONSUMPTION = 2
+    BACKUP = 4
+    TIME_OF_USE = 5

--- a/bluetti_bt_lib/fields/FieldName.py
+++ b/bluetti_bt_lib/fields/FieldName.py
@@ -45,6 +45,8 @@ class FieldName(Enum):
     CTRL_SPLIT_PHASE = "ctrl_split_phase"
     CTRL_SPLIT_PHASE_MODE = "ctrl_split_phase_mode"
     CTRL_UPS_MODE = "ctrl_ups_mode"
+    CTRL_WORKING_MODE = "ctrl_working_mode"
+    CTRL_CHARGE_FROM_GRID = "ctrl_charge_from_grid"
     DC_INPUT_CURRENT = "dc_input_current"
     DC_INPUT_POWER = "dc_input_power"
     DC_INPUT_VOLTAGE = "dc_input_voltage"

--- a/bluetti_bt_lib/fields/NumberField.py
+++ b/bluetti_bt_lib/fields/NumberField.py
@@ -1,0 +1,9 @@
+from .UIntField import UIntField
+
+
+class NumberField(UIntField):
+    def is_writeable(self) -> bool:
+        return True
+
+    def allowed_write_type(self, value) -> bool:
+        return isinstance(value, (int, float))

--- a/bluetti_bt_lib/fields/__init__.py
+++ b/bluetti_bt_lib/fields/__init__.py
@@ -13,4 +13,5 @@ from .StringField import *
 from .SwapStringField import *
 from .SwitchField import *
 from .UIntField import *
+from .NumberField import *
 from .VersionField import *

--- a/tests/base_devices/bluetti_device_test.py
+++ b/tests/base_devices/bluetti_device_test.py
@@ -5,6 +5,7 @@ from bluetti_bt_lib.fields import (
     BoolField,
     BoolFieldNonZero,
     EnumField,
+    NumberField,
     SelectField,
     StringField,
     SerialNumberField,
@@ -168,3 +169,45 @@ class TestBluettiDevice(unittest.TestCase):
 
         self.assertEqual(len(device.get_select_fields()), 1)
         self.assertEqual(len(device.get_sensor_fields()), 1)
+
+    def test_number_fields(self):
+        fields = [
+            NumberField(FieldName.BATTERY_SOC_RANGE_START, 2022, min=0, max=100),
+            NumberField(FieldName.BATTERY_SOC_RANGE_END, 2023, min=0, max=100),
+            SwitchField(FieldName.CTRL_AC, 150),
+        ]
+
+        device = BluettiDevice(fields=fields, pack_fields=[], max_packs=0)
+
+        self.assertEqual(len(device.get_number_fields()), 2)
+        self.assertEqual(len(device.get_switch_fields()), 1)
+        # NumberField should not appear in sensor fields
+        self.assertEqual(len(device.get_sensor_fields()), 0)
+
+    def test_build_write_command_number_field(self):
+        fields = [
+            NumberField(FieldName.BATTERY_SOC_RANGE_START, 2022, min=0, max=100),
+        ]
+
+        device = BluettiDevice(fields)
+
+        command = device.build_write_command(
+            FieldName.BATTERY_SOC_RANGE_START.value, 75
+        )
+
+        self.assertEqual(command.address, 2022)
+        self.assertEqual(command.value, 75)
+
+    def test_build_write_command_number_field_float(self):
+        fields = [
+            NumberField(FieldName.BATTERY_SOC_RANGE_START, 2022, min=0, max=100),
+        ]
+
+        device = BluettiDevice(fields)
+
+        command = device.build_write_command(
+            FieldName.BATTERY_SOC_RANGE_START.value, 75.9
+        )
+
+        self.assertEqual(command.address, 2022)
+        self.assertEqual(command.value, 75)

--- a/tests/fields/number_field_test.py
+++ b/tests/fields/number_field_test.py
@@ -1,0 +1,58 @@
+import struct
+import unittest
+
+from bluetti_bt_lib.fields import NumberField, FieldName
+
+
+class TestNumberField(unittest.TestCase):
+    def test_is_writeable(self):
+        field = NumberField(FieldName.BATTERY_SOC_RANGE_START, 2022, min=0, max=100)
+        self.assertTrue(field.is_writeable())
+
+    def test_allowed_write_type_int(self):
+        field = NumberField(FieldName.BATTERY_SOC_RANGE_START, 2022, min=0, max=100)
+        self.assertTrue(field.allowed_write_type(50))
+
+    def test_allowed_write_type_float(self):
+        field = NumberField(FieldName.BATTERY_SOC_RANGE_START, 2022, min=0, max=100)
+        self.assertTrue(field.allowed_write_type(50.5))
+
+    def test_allowed_write_type_string(self):
+        field = NumberField(FieldName.BATTERY_SOC_RANGE_START, 2022, min=0, max=100)
+        self.assertFalse(field.allowed_write_type("50"))
+
+    def test_allowed_write_type_bool(self):
+        field = NumberField(FieldName.BATTERY_SOC_RANGE_START, 2022, min=0, max=100)
+        # bool is a subclass of int in Python, so this is expected to be True
+        self.assertTrue(field.allowed_write_type(True))
+
+    def test_parse(self):
+        field = NumberField(FieldName.BATTERY_SOC_RANGE_START, 2022, min=0, max=100)
+        data = struct.pack("!H", 75)
+        self.assertEqual(field.parse(data), 75)
+
+    def test_in_range_valid(self):
+        field = NumberField(FieldName.BATTERY_SOC_RANGE_START, 2022, min=0, max=100)
+        self.assertTrue(field.in_range(50))
+        self.assertTrue(field.in_range(0))
+        self.assertTrue(field.in_range(100))
+
+    def test_in_range_below_min(self):
+        field = NumberField(FieldName.BATTERY_SOC_RANGE_START, 2022, min=0, max=100)
+        self.assertFalse(field.in_range(-1))
+
+    def test_in_range_above_max(self):
+        field = NumberField(FieldName.BATTERY_SOC_RANGE_START, 2022, min=0, max=100)
+        self.assertFalse(field.in_range(101))
+
+    def test_address(self):
+        field = NumberField(FieldName.BATTERY_SOC_RANGE_START, 2022, min=0, max=100)
+        self.assertEqual(field.address, 2022)
+
+    def test_size(self):
+        field = NumberField(FieldName.BATTERY_SOC_RANGE_START, 2022, min=0, max=100)
+        self.assertEqual(field.size, 1)
+
+    def test_name(self):
+        field = NumberField(FieldName.BATTERY_SOC_RANGE_START, 2022, min=0, max=100)
+        self.assertEqual(field.name, FieldName.BATTERY_SOC_RANGE_START.value)


### PR DESCRIPTION
## Summary

Expands the minimal AP300 device definition with full sensor and control support:

- **Sensors**: time_remaining, dc/ac output power, dc/ac input power, ac input frequency/voltage/current, ac output frequency/voltage
- **Switches**: ctrl_ac, ctrl_dc, ctrl_eco_dc, ctrl_eco_ac, ctrl_power_lifting, ctrl_charge_from_grid
- **Selects**: ctrl_charging_mode (ChargingMode), ctrl_working_mode (WorkingMode), ctrl_display_timeout (DisplayMode)
- **Numbers**: battery_soc_range_start/end (0–100%) — new `NumberField` type for writeable numeric slider controls

### New components

| File | Description |
|------|-------------|
| `fields/NumberField.py` | Writeable numeric field extending UIntField — `is_writeable()` returns True, accepts int/float |
| `enums/working_mode.py` | WorkingMode enum: CUSTOM=1, SELF_CONSUMPTION=2, BACKUP=4, TIME_OF_USE=5 |

### Modified files

| File | Change |
|------|--------|
| `devices/ap300.py` | Replaced minimal 5-sensor definition with full sensor + control layout |
| `fields/FieldName.py` | Added `CTRL_WORKING_MODE`, `CTRL_CHARGE_FROM_GRID` |
| `fields/__init__.py` | Added `NumberField` export |
| `enums/__init__.py` | Added `working_mode` export |
| `base_devices/bluetti_device.py` | NumberField handling in `build_write_command` (float→int), `get_number_fields()`, excluded from `get_sensor_fields()` |
| `__init__.py` | Added `NumberField` to package exports |

### Tests

- 11 new tests for `NumberField` (writeable, parse, range validation, allowed write types)
- 3 new tests for `BluettiDevice` NumberField integration (get_number_fields, build_write_command with int and float)
- All **88 tests pass**

### Notes

- Register addresses confirmed via real-world testing on an AP300 device
- Sensors work immediately; **control writes on encrypted devices** (like the AP300) require encrypted write support — see PR #59 and PR #60
- A companion PR for [hassio-bluetti-bt](https://github.com/Patrick762/hassio-bluetti-bt) adds the HA number platform and translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)