### PR TITLE
feat: configurable Modbus slave address for 2nd-gen IoT devices

### DIFF
--- a/bluetti_bt_lib/base_devices/base_device_v1.py
+++ b/bluetti_bt_lib/base_devices/base_device_v1.py
@@ -29,20 +29,20 @@ class BaseDeviceV1(BluettiDevice):
         )
 
     def get_full_registers_range(self) -> List[ReadableRegisters]:
-        return [ReadableRegisters(i, 10) for i in range(1, 8000, 10)]
+        return [ReadableRegisters(i, 10, self.slave_address) for i in range(1, 8000, 10)]
 
     def get_device_type_registers(self) -> List[ReadableRegisters]:
         return [
-            ReadableRegisters(10, 6),
+            ReadableRegisters(10, 6, self.slave_address),
         ]
 
     def get_device_sn_registers(self) -> List[ReadableRegisters]:
         return [
-            ReadableRegisters(17, 4),
+            ReadableRegisters(17, 4, self.slave_address),
         ]
 
     def get_iot_version(self) -> int:
         return 1
 
     def get_pack_selector(self, pack: int) -> WriteableRegister:
-        return WriteableRegister(3006, pack)
+        return WriteableRegister(3006, pack, self.slave_address)

--- a/bluetti_bt_lib/base_devices/base_device_v2.py
+++ b/bluetti_bt_lib/base_devices/base_device_v2.py
@@ -25,16 +25,16 @@ class BaseDeviceV2(BluettiDevice):
         )
 
     def get_full_registers_range(self) -> List[ReadableRegisters]:
-        return [ReadableRegisters(i, 10) for i in range(1, 20000, 10)]
+        return [ReadableRegisters(i, 10, self.slave_address) for i in range(1, 20000, 10)]
 
     def get_device_type_registers(self) -> List[ReadableRegisters]:
         return [
-            ReadableRegisters(110, 6),
+            ReadableRegisters(110, 6, self.slave_address),
         ]
 
     def get_device_sn_registers(self) -> List[ReadableRegisters]:
         return [
-            ReadableRegisters(116, 4),
+            ReadableRegisters(116, 4, self.slave_address),
         ]
 
     def get_iot_version(self) -> int:

--- a/bluetti_bt_lib/base_devices/bluetti_device.py
+++ b/bluetti_bt_lib/base_devices/bluetti_device.py
@@ -5,6 +5,9 @@ from ..fields import DeviceField, BoolField, BoolFieldNonZero, SwitchField, Sele
 
 
 class BluettiDevice:
+    # Modbus slave address; override in subclasses (e.g., AP300 uses 0)
+    slave_address = 1
+
     def __init__(
         self,
         fields: List[DeviceField],
@@ -22,7 +25,7 @@ class BluettiDevice:
         self.pack_polling_registers: List[ReadableRegisters] = []
 
         for f in self.fields:
-            group = ReadableRegisters(f.address, f.size)
+            group = ReadableRegisters(f.address, f.size, self.slave_address)
             self.polling_registers.append(group)
 
         # Check if we even have battery pack fields defined
@@ -31,7 +34,7 @@ class BluettiDevice:
 
         # Optimize amount of registers to separately request
         for f in self.pack_fields:
-            group = ReadableRegisters(f.address, f.size)
+            group = ReadableRegisters(f.address, f.size, self.slave_address)
             self.pack_polling_registers.append(group)
 
     def get_polling_registers(self) -> List[ReadableRegisters]:
@@ -112,7 +115,7 @@ class BluettiDevice:
         elif isinstance(field, SwitchField):
             value = 1 if value else 0
 
-        return WriteableRegister(field.address, value)
+        return WriteableRegister(field.address, value, self.slave_address)
 
     def get_bool_fields(self):
         """Returns all bool fields for this device"""

--- a/bluetti_bt_lib/registers/DeviceRegister.py
+++ b/bluetti_bt_lib/registers/DeviceRegister.py
@@ -11,11 +11,11 @@ class RegisterAction(Enum):
 
 
 class DeviceRegister:
-    def __init__(self, register_action: RegisterAction, data: bytes):
+    def __init__(self, register_action: RegisterAction, data: bytes, slave_address: int = 1):
         self.register_action = register_action
 
         self.cmd = bytearray(len(data) + 4)
-        self.cmd[0] = 1
+        self.cmd[0] = slave_address
         self.cmd[1] = register_action.value
         self.cmd[2:-2] = data
         struct.pack_into("<H", self.cmd, -2, modbus_crc(self.cmd[:-2]))

--- a/bluetti_bt_lib/registers/ReadableRegisters.py
+++ b/bluetti_bt_lib/registers/ReadableRegisters.py
@@ -4,9 +4,9 @@ from . import DeviceRegister, RegisterAction
 
 
 class ReadableRegisters(DeviceRegister):
-    def __init__(self, starting_address: int, quantity: int):
+    def __init__(self, starting_address: int, quantity: int, slave_address: int = 1):
         super().__init__(
-            RegisterAction.READ, struct.pack("!HH", starting_address, quantity)
+            RegisterAction.READ, struct.pack("!HH", starting_address, quantity), slave_address
         )
         self.starting_address = starting_address
         self.quantity = quantity

--- a/bluetti_bt_lib/registers/WriteableRegister.py
+++ b/bluetti_bt_lib/registers/WriteableRegister.py
@@ -4,8 +4,8 @@ from . import DeviceRegister, RegisterAction
 
 
 class WriteableRegister(DeviceRegister):
-    def __init__(self, address: int, value: int):
-        super().__init__(RegisterAction.WRITE, struct.pack("!HH", address, value))
+    def __init__(self, address: int, value: int, slave_address: int = 1):
+        super().__init__(RegisterAction.WRITE, struct.pack("!HH", address, value), slave_address)
         self.address = address
         self.value = value
 


### PR DESCRIPTION
## Summary

- Adds a configurable `slave_address` parameter (default `1`) to `DeviceRegister`, `ReadableRegisters`, and `WriteableRegister`
- Adds a `slave_address` class attribute to `BluettiDevice` that device subclasses can override
- Threads `self.slave_address` through all register construction sites in `BluettiDevice`, `BaseDeviceV1`, and `BaseDeviceV2`

## Why

Bluetti "2nd generation IoT" devices (AP300, PBOX, EBOX, COMBOX, AT1, D100S, D100P, A80, A80P, A100S, AC_HUB, DC_HUB) use **Modbus slave address 0** instead of the standard address 1. The library currently hardcodes `self.cmd[0] = 1` in `DeviceRegister.__init__()`.

With the wrong slave address, these devices return all-zero data for every register and silently ignore writes — the ECDH handshake succeeds, Modbus frames are valid, but all data fields read as `0x0000`.

This was confirmed by decompiling the official Bluetti Android APK, which sets `modbusSlaveAddr = 0` for devices where `is2GenerationIoT()` returns true (`ConnectManager.java` line 955, `DeviceConnUtil.java` line 1537).

## How to use

Device subclasses that need slave address 0 just add a class attribute:

```python
class AP300(BaseDeviceV2):
    slave_address = 0  # 2nd generation IoT device
```

This is **fully backward-compatible** — all existing devices default to `slave_address=1` and behave identically to before.

## Related

- Depends on #61 for the AP300 device class (which should add `slave_address = 0`)
- Tested on a real AP300 — reads and writes confirmed working with slave address 0

## Test plan

- [x] All 73 existing tests pass
- [x] Verified AP300 polling registers use `cmd[0] = 0` when `slave_address = 0`
- [x] Verified AC70 and BaseDeviceV1 still use `cmd[0] = 1`
- [x] Live-tested on real AP300: full sensor data reads + AC switch write confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)