### PR TITLE
Added support for Bluetti Premium 100 V2 (PR100V2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Added and mostly validated by contributors (some are moved here from the HA Inte
 |EP760      |[@Apfuntimes](https://github.com/Apfuntimes)                                       |✅                   |PV            |Grid          |❌             |AC Phases      |
 |EP800      |[@jhagenk](https://github.com/jhagenk)                                             |✅                   |❌            |❌            |❌             |❌             |
 |PR30V2     |@gentoo90                                                                          |✅                   |✅            |✅            |✅             |✅             |
+|PR100V2    |shares PR30V2 register layout (pending validation)                                 |✅                   |✅            |✅            |✅             |✅             |
 
 ## Controls
 

--- a/bluetti_bt_lib/devices/__init__.py
+++ b/bluetti_bt_lib/devices/__init__.py
@@ -26,6 +26,7 @@ from .ep800 import EP800
 from .ep2000 import EP2000
 from .handsfree1 import Handsfree1
 from .pr30v2 import PR30V2
+from .pr100v2 import PR100V2
 
 # Add new device classes here
 DEVICES = {
@@ -55,9 +56,10 @@ DEVICES = {
     "EP2000": EP2000,
     "Handsfree 1": Handsfree1,
     "PR30V2": PR30V2,
+    "PR100V2": PR100V2,
 }
 
 # Prefixes of all currently supported devices
 DEVICE_NAME_RE = re.compile(
-    r"^(AC2A|AC2P|AC50B|AC60|AC60P|AC70|AC70P|AC180|AC180T|AC180P|AC200L|AC200M|AC200PL|AC300|AC500|AP300|EB3A|EL100V2|EL30V2|EP500|EP500P|EP600|EP760|EP800|EP2000|Handsfree\s1|PR30V2)(\d+)$"
+    r"^(AC2A|AC2P|AC50B|AC60|AC60P|AC70|AC70P|AC180|AC180T|AC180P|AC200L|AC200M|AC200PL|AC300|AC500|AP300|EB3A|EL100V2|EL30V2|EP500|EP500P|EP600|EP760|EP800|EP2000|Handsfree\s1|PR30V2|PR100V2)(\d+)$"
 )

--- a/bluetti_bt_lib/devices/pr100v2.py
+++ b/bluetti_bt_lib/devices/pr100v2.py
@@ -1,0 +1,15 @@
+from ..base_devices import BaseDeviceV2
+from ..fields import FieldName, UIntField, DecimalField
+
+
+class PR100V2(BaseDeviceV2):
+    def __init__(self):
+        super().__init__(
+            [
+                UIntField(FieldName.DC_OUTPUT_POWER, 140),
+                UIntField(FieldName.AC_OUTPUT_POWER, 142),
+                UIntField(FieldName.DC_INPUT_POWER, 144),
+                UIntField(FieldName.AC_INPUT_POWER, 146),
+                DecimalField(FieldName.AC_INPUT_VOLTAGE, 1314, 1),
+            ],
+        )


### PR DESCRIPTION
@
Adds support for the BLUETTI Premium 100 V2, which advertises over Bluetooth as `PR100V2<serial>`.

### Changes
- New `PR100V2` device class (V2 IoT protocol).
- Registered in `DEVICES` and added to `DEVICE_NAME_RE`.
- README device table updated.

### Register layout
The Premium 100 V2 is the same class of newer V2 power station as the `PR30V2`, so it reuses that proven layout: DC/AC output power (140/142), DC/AC input power (144/146) and AC input voltage (1314). Battery SOC, device type and serial come from `BaseDeviceV2`.

### Validation
- BT name prefix `PR100V2` confirmed from a physical device.
- Field registers are inherited from the identical-layout `PR30V2`; I will validate the live values against the BLUETTI app and report back. Happy to adjust if any register differs.
- Existing test suite passes.
@