### PR TITLE
Add EP760 device registration and CTRL_AC control support

### DIFF
--- a/bluetti_bt_lib/devices/__init__.py
+++ b/bluetti_bt_lib/devices/__init__.py
@@ -22,6 +22,7 @@ from .el30v2 import EL30V2
 from .ep500 import EP500
 from .ep500p import EP500P
 from .ep600 import EP600
+from .ep760 import EP760
 from .ep800 import EP800
 from .ep2000 import EP2000
 from .handsfree1 import Handsfree1
@@ -51,6 +52,7 @@ DEVICES = {
     "EP500": EP500,
     "EP500P": EP500P,
     "EP600": EP600,
+    "EP760": EP760,
     "EP800": EP800,
     "EP2000": EP2000,
     "Handsfree 1": Handsfree1,

--- a/bluetti_bt_lib/devices/ep760.py
+++ b/bluetti_bt_lib/devices/ep760.py
@@ -1,6 +1,5 @@
 from ..base_devices import BaseDeviceV2
-from ..fields import FieldName, UIntField, DecimalField
-
+from ..fields import FieldName, UIntField, DecimalField, SwitchField
 
 class EP760(BaseDeviceV2):
     def __init__(self):
@@ -23,5 +22,6 @@ class EP760(BaseDeviceV2):
                 UIntField(FieldName.AC_P1_POWER, 1510),
                 DecimalField(FieldName.AC_P1_VOLTAGE, 1511, 1),
                 DecimalField(FieldName.AC_P1_CURRENT, 1512, 1),
-            ],
+                SwitchField(FieldName.CTRL_AC, 2208),             
+           ],
         )


### PR DESCRIPTION
- EP760 was matched by DEVICE_NAME_RE but missing from the DEVICES dict/imports, causing bluetti-write to fail with 'Unsupported powerstation type' despite the device class already existing.
- Added SwitchField(FieldName.CTRL_AC, 2208) to EP760, identified empirically by diffing bluetti-readall snapshots taken with AC output toggled on/off via the official app. Confirmed working in both directions on physical EP760 hardware.

Device Name: EP760
Device Bluetooth Prefix: PBOX
Device IoT protocol: 2
Device with encryption: No
Similar device if available: EP600

Goal is to use HAOS to monitor export energy prices (octopus agile) and export when above certain thresholds