### PR TITLE
Fix 10x internal AC voltage/frequency on AC500

### DIFF
--- a/bluetti_bt_lib/devices/ac500.py
+++ b/bluetti_bt_lib/devices/ac500.py
@@ -16,8 +16,8 @@ class AC500(BaseDeviceV1):
         super().__init__(
             [
                 EnumField(FieldName.AC_OUTPUT_MODE, 70, OutputMode),
-                DecimalField(FieldName.INTERNAL_AC_VOLTAGE, 71, 1, 10),
-                DecimalField(FieldName.INTERNAL_AC_FREQUENCY, 74, 2, 10),
+                DecimalField(FieldName.INTERNAL_AC_VOLTAGE, 71, 1),
+                DecimalField(FieldName.INTERNAL_AC_FREQUENCY, 74, 2),
                 DecimalField(FieldName.AC_INPUT_VOLTAGE, 77, 1),
                 DecimalField(FieldName.AC_INPUT_FREQUENCY, 80, 2),
                 DecimalField(FieldName.PV_S1_VOLTAGE, 86, 1),


### PR DESCRIPTION
## Problem

`DecimalField.parse()` computes `(raw / 10**scale) * multiplier`. AC500 defines:

```python
DecimalField(FieldName.INTERNAL_AC_VOLTAGE, 71, 1, 10),
DecimalField(FieldName.INTERNAL_AC_FREQUENCY, 74, 2, 10),
```

The AC500 reports these registers in tenths/hundredths (same as AC300), so the `multiplier=10` cancels the scale and both values render 10x too high — 230.4 V shows as **2304 V**, 50.0 Hz as **500 Hz**.

Fixes Patrick762/hassio-bluetti-bt#248.

## Verification

Measured on a real AC500 (grid-tied): with this fix `internal_ac_voltage` reads 233–238 V, tracking the same unit's `ac_input_voltage` (no multiplier, always correct) within 0.3 V, and `internal_ac_frequency` reads 50.0 Hz matching `ac_input_frequency`. Without it, the same polls render 2334–2380 V / 500 Hz.

Parse sanity check: raw `2334` → `233.4`, raw `5001` → `50.01`. Full test suite passes (73 passed).

## Why AC500 only (and #145)

AC200L/M/PL share the same field pattern but there the `multiplier=10` is **intentional**: that family reports integer volts, and the multiplier was added from device feedback to correct 23 V → 230 V (Patrick762/hassio-bluetti-bt#145, integration commit b37276e) — the exact opposite direction of the AC500 bug. That likely means #145 is already resolved on current 0.2.x and just needs reporter confirmation; if reports still show wrong values there, the fix would mirror this one on the AC200x definitions. I'm leaving those untouched — I have no AC200-series hardware to verify against, and this family has already been bitten once by cross-device assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
