### PR TITLE
Add FridgePower support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Added and mostly validated by contributors (some are moved here from the HA Inte
 |EP500P     |bluetti-mqtt                                                                       |✅                   |✅            |✅            |✅             |✅             |
 |EP760      |[@Apfuntimes](https://github.com/Apfuntimes)                                       |✅                   |PV            |Grid          |❌             |AC Phases      |
 |EP800      |[@jhagenk](https://github.com/jhagenk)                                             |✅                   |❌            |❌            |❌             |❌             |
+|FP         |[@madsciencetist](https://github.com/madsciencetist)                               |✅                   |❌            |✅            |✅             |✅             |
 |PR30V2     |@gentoo90                                                                          |✅                   |✅            |✅            |✅             |✅             |
 |PR100V2    |shares PR30V2 register layout (pending validation)                                 |✅                   |✅            |✅            |✅             |✅             |
 
@@ -64,6 +65,7 @@ Added and mostly validated by contributors:
 |-----------|---------------------------------------------------------|-------|-------|-------------|---------------|-------------|
 |AC200L     |bluetti-mqtt, [@seaburger](https://github.com/seaburger) |✅     |✅     |✅           |❌             |❌           |
 |EL30V2     |[@x3ccd4828](https://github.com/x3ccd4828)               |✅     |✅     |❌           |❌             |❌           |
+|FP         |[@madsciencetist](https://github.com/madsciencetist)     |✅     |✅     |❌           |❌             |❌           |
 
 ## Battery pack data
 

--- a/bluetti_bt_lib/bluetooth/device_recognizer.py
+++ b/bluetti_bt_lib/bluetooth/device_recognizer.py
@@ -55,7 +55,8 @@ async def recognize_device(
 
             # We only need 6 registers to get the device type
             data = await device_reader.read(
-                bluetti_device.get_device_type_registers(),
+                bluetti_device.get_device_type_registers()
+                + bluetti_device.get_device_sn_registers(),
             )
 
             if data is None:
@@ -82,23 +83,9 @@ async def recognize_device(
                 _LOGGER.warning("Device has populated type_data with trash data")
                 continue
 
-            data = await device_reader.read(
-                bluetti_device.get_device_sn_registers(),
-            )
-
-            if data is None:
-                # Should never happen
-                return DeviceRecognizerResult(
-                    type_data,
-                    bluetti_device.get_iot_version(),
-                    device_reader.config.use_encryption,
-                    "000000000000",  # Use dummy SN
-                )
-
             sn_data = data.get(FieldName.DEVICE_SN.value)
 
-            if not isinstance(sn_data, int) or sn_data == "":
-                # Should never happen
+            if not isinstance(sn_data, int):
                 return DeviceRecognizerResult(
                     type_data,
                     bluetti_device.get_iot_version(),

--- a/bluetti_bt_lib/devices/__init__.py
+++ b/bluetti_bt_lib/devices/__init__.py
@@ -25,6 +25,7 @@ from .ep600 import EP600
 from .ep760 import EP760
 from .ep800 import EP800
 from .ep2000 import EP2000
+from .fp import FP
 from .handsfree1 import Handsfree1
 from .pr30v2 import PR30V2
 from .pr100v2 import PR100V2
@@ -56,6 +57,7 @@ DEVICES = {
     "EP760": EP760,
     "EP800": EP800,
     "EP2000": EP2000,
+    "FP": FP,
     "Handsfree 1": Handsfree1,
     "PR30V2": PR30V2,
     "PR100V2": PR100V2,
@@ -63,5 +65,5 @@ DEVICES = {
 
 # Prefixes of all currently supported devices
 DEVICE_NAME_RE = re.compile(
-    r"^(AC2A|AC2P|AC50B|AC60|AC60P|AC70|AC70P|AC180|AC180T|AC180P|AC200L|AC200M|AC200PL|AC300|AC500|AP300|EB3A|EL100V2|EL30V2|EP500|EP500P|EP600|EP760|EP800|EP2000|Handsfree\s1|PR30V2|PR100V2)(\d+)$"
+    r"^(AC2A|AC2P|AC50B|AC60|AC60P|AC70|AC70P|AC180|AC180T|AC180P|AC200L|AC200M|AC200PL|AC300|AC500|AP300|EB3A|EL100V2|EL30V2|EP500|EP500P|EP600|EP760|EP800|EP2000|FP|Handsfree\s1|PR30V2|PR100V2)(\d+)$"
 )

--- a/bluetti_bt_lib/devices/fp.py
+++ b/bluetti_bt_lib/devices/fp.py
@@ -1,0 +1,31 @@
+from ..base_devices import BaseDeviceV2
+from ..enums import ChargingMode, EcoMode, UpsMode
+from ..fields import FieldName, UIntField, IntField, DecimalField, SwitchField, SelectField
+
+
+class FP(BaseDeviceV2):
+    def __init__(self):
+        super().__init__(
+            [
+                DecimalField(FieldName.TIME_REMAINING, 104, 0, 1/60, precision=2),
+                UIntField(FieldName.DC_OUTPUT_POWER, 140),
+                UIntField(FieldName.AC_OUTPUT_POWER, 142),
+                UIntField(FieldName.DC_INPUT_POWER, 144),
+                IntField(FieldName.AC_INPUT_POWER, 146, multiplier=-1),
+                DecimalField(FieldName.DC_INPUT_VOLTAGE, 1213, 1),
+                DecimalField(FieldName.DC_INPUT_CURRENT, 1214, 1),
+                DecimalField(FieldName.AC_INPUT_FREQUENCY, 1300, 1),
+                UIntField(FieldName.AC_INPUT_VOLTAGE, 1314, 0.1),
+                IntField(FieldName.AC_INPUT_CURRENT, 1315, multiplier=-0.1),
+                DecimalField(FieldName.AC_OUTPUT_FREQUENCY, 1500, 1),
+                DecimalField(FieldName.AC_OUTPUT_VOLTAGE, 1511, 1),
+                SwitchField(FieldName.CTRL_AC, 2011),
+                SwitchField(FieldName.CTRL_DC, 2012),
+                SwitchField(FieldName.CTRL_ECO_AC, 2017),
+                SelectField(FieldName.CTRL_ECO_TIME_MODE_AC, 2018, EcoMode),
+                UIntField(FieldName.CTRL_ECO_MIN_POWER_AC, 2019),
+                SelectField(FieldName.CTRL_CHARGING_MODE, 2020, ChargingMode),
+                SwitchField(FieldName.CTRL_POWER_LIFTING, 2021),
+                SelectField(FieldName.CTRL_UPS_MODE, 3001, UpsMode),
+            ],
+        )

--- a/bluetti_bt_lib/fields/DecimalField.py
+++ b/bluetti_bt_lib/fields/DecimalField.py
@@ -13,16 +13,21 @@ class DecimalField(DeviceField):
         multiplier: float = 1,
         min: Decimal | None = None,
         max: Decimal | None = None,
+        precision: int | None = None,
     ):
         super().__init__(name, address, 1)
         self.scale = scale
         self.multiplier = multiplier
         self.min = min
         self.max = max
+        self.precision = precision
 
     def parse(self, data: bytes) -> Decimal:
         val = Decimal(struct.unpack("!H", data)[0])
-        return (val / 10 ** self.scale) * Decimal(self.multiplier)
+        result = (val / 10 ** self.scale) * Decimal(self.multiplier)
+        if self.precision is not None:
+            return round(result, self.precision)
+        return result
 
     def in_range(self, value: Decimal) -> bool:
         if self.min is not None and self.min > value:

--- a/bluetti_bt_lib/fields/IntField.py
+++ b/bluetti_bt_lib/fields/IntField.py
@@ -1,0 +1,19 @@
+import struct
+
+from . import FieldName
+from .UIntField import UIntField
+
+
+class IntField(UIntField):
+    def parse(self, data: bytes) -> int:
+        val = struct.unpack("!h", data)[0]
+        if self.multiplier != 1:
+            val = round(val * self.multiplier, 2)
+        return val
+
+    def in_range(self, value: int) -> bool:
+        if self.min is not None and self.min > value:
+            return False
+        if self.max is not None and self.max < value:
+            return False
+        return True

--- a/bluetti_bt_lib/fields/__init__.py
+++ b/bluetti_bt_lib/fields/__init__.py
@@ -12,5 +12,6 @@ from .SerialNumberField import *
 from .StringField import *
 from .SwapStringField import *
 from .SwitchField import *
+from .IntField import *
 from .UIntField import *
 from .VersionField import *


### PR DESCRIPTION
Add support for new product "FridgePower", device type `FP`.
    
Registers appear to match those of the AC70, with two exception for which I added support:
  1. `TIME_REMAINING` is in decimal-hours rather than minutes.
  2. `AC_INPUT_POWER` and `AC_INPUT_CURRENT` are signed, and are negative when current
        is flowing into the device.

Also grab both the device type and serial number in the same BLE connection to prevent it being read as `FP000000000000` (the `# Should never happen` has happened)