### PR TITLE
Guard against InvalidStateError from stale BLE notifications in DeviceReader._notification_handler

### DIFF
--- a/bluetti_bt_lib/bluetooth/device_reader.py
+++ b/bluetti_bt_lib/bluetooth/device_reader.py
@@ -322,10 +322,16 @@ class DeviceReader:
             # Handle as message
             data = decrypted.buffer
 
-        # Save data
-        self.notify_response.extend(data)
-
         if self.notify_future is None:
             return
+
+        if self.notify_future.done():
+            # Future was already resolved or cancelled (e.g. response timeout),
+            # so this is a late or duplicate notification we can safely drop
+            self.logger.debug("Dropping notification for already completed future")
+            return
+
+        # Save data
+        self.notify_response.extend(data)
 
         self.notify_future.set_result(self.notify_response)

--- a/tests/device_reader_test.py
+++ b/tests/device_reader_test.py
@@ -46,6 +46,32 @@ class TestDeviceReader(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data.get(FieldName.DC_OUTPUT_POWER.value), 7)
         self.assertEqual(data.get(FieldName.BATTERY_SOC.value), 78)
 
+    async def test_notification_with_done_future(self):
+        # Late or duplicate notifications must not raise InvalidStateError (#64)
+        device = BaseDeviceV1()
+        reader = DeviceReader(
+            "00:11:00:11:00:11",
+            device,
+            asyncio.Future,
+            ble_client=self.ble_mock,
+        )
+
+        # First notification resolves the future
+        reader.notify_future = asyncio.Future()
+        await reader._notification_handler(0, bytearray(b"\x01\x02"))
+        self.assertTrue(reader.notify_future.done())
+
+        # Duplicate notification arriving after the future is resolved
+        await reader._notification_handler(0, bytearray(b"\x03\x04"))
+        self.assertEqual(reader.notify_future.result(), bytearray(b"\x01\x02"))
+
+        # Late notification after the future was cancelled (response timeout)
+        reader.notify_response = bytearray()
+        reader.notify_future = asyncio.Future()
+        reader.notify_future.cancel()
+        await reader._notification_handler(0, bytearray(b"\x05\x06"))
+        self.assertTrue(reader.notify_future.cancelled())
+
     async def test_read_soc_wrong(self):
         # SOC
         self.ble_mock.add_r_int(43, 1234)


### PR DESCRIPTION
Fixes #64

## Problem

`DeviceReader._notification_handler` calls `self.notify_future.set_result(...)` unconditionally. If the pending response future is already done — resolved by an earlier notification, or cancelled by the 5s `asyncio.wait_for` timeout in `_async_send_command` — a late or duplicate BLE notification raises `asyncio.InvalidStateError` inside the notification task, which surfaces as an unhandled task exception.

Seen in the wild via the `hassio-bluetti-bt` custom integration (v0.2.2, pinning `bluetti-bt-lib==0.1.7`) on Home Assistant / Python 3.14, flooding the logs:

```
<class 'asyncio.exceptions.InvalidStateError'>: invalid state
future: <Task finished name='Task-XXXXXX'
  coro=<DeviceReader._notification_handler() done,
  defined at .../site-packages/bluetti_bt_lib/bluetooth/device_reader.py:252>
  exception=InvalidStateError('invalid state')>
```

Same root cause as the traceback reported in #64 (line 280 in 0.1.6 is the same `set_result` call).

## Fix

Guard the resolution with `notify_future.done()` (which also covers cancellation) and drop the stale notification with a debug log so it stays diagnosable. The guard runs before `notify_response.extend(data)` so a late fragment can't mutate a `bytearray` result already delivered to the waiter in `_async_send_command`.

Dropping is safe: the first response wins, and the existing consumer-side timeout already handles genuinely missed responses.

## Testing

- Added `test_notification_with_done_future` covering both the duplicate-notification and cancelled-future (timeout) paths; it fails with `InvalidStateError` before the fix and passes after.
- Full suite from `Dockerfile.test` passes (67 tests across `tests/`, `fields/`, `registers/`, `base_devices/`, `devices/`).
- Changed files checked with `black --target-version py310` (the remaining reformat hints in `device_reader.py` are on pre-existing lines, left untouched to keep the diff minimal).

No version bump included — left to the maintainer since `setup.py` takes the version from `LIB_VERSION` at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcnWB3thiiJUoaHHJDS9r5
