### PR TITLE
Drop stdlib modules asyncio and logging from dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 async_timeout
-asyncio
 bleak
 bleak_retry_connector
 crcmod
 cryptography
-logging
 pyasn1

--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,10 @@ setup(
     packages=find_packages(),
     install_requires=[
         "async_timeout",
-        "asyncio",
         "bleak",
         "bleak_retry_connector",
         "crcmod",
         "cryptography",
-        "logging",
         "pyasn1",
     ],
     keywords=[],


### PR DESCRIPTION
`asyncio` and `logging` are part of the Python standard library, but both are declared in `install_requires` and `requirements.txt`. pip therefore resolves them against PyPI, where the same names are taken by unrelated distributions:

- [`asyncio`](https://pypi.org/project/asyncio/) on PyPI is the abandoned 3.4-era backport, last released in 2015 and not installable on modern Python;
- [`logging`](https://pypi.org/project/logging/) on PyPI is a 2005 package written for Python 2.

Installing either is at best a wasted download and at worst a hard resolver failure or a shadowed stdlib module. This is easiest to hit when the library is installed by Home Assistant, which resolves requirements against its own wheel index at integration load.

Removing them changes nothing at runtime — the code keeps importing the stdlib modules exactly as before — and the install resolves against six real dependencies instead of eight.

The existing unittest suite passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)