### PR TITLE
Tolerate BLE write failures during the encrypted handshake

### DIFF
--- a/bluetti_bt_lib/bluetooth/device_reader.py
+++ b/bluetti_bt_lib/bluetooth/device_reader.py
@@ -263,7 +263,12 @@ class DeviceReader:
 
                 if message.type == MessageType.CHALLENGE:
                     challenge_response = self.encryption.msg_challenge(message)
-                    await self.client.write_gatt_char(WRITE_UUID, challenge_response)
+                    try:
+                        await self.client.write_gatt_char(WRITE_UUID, challenge_response)
+                    except BleakError as err:
+                        self.logger.warning(
+                            "Challenge response write failed: %s", err
+                        )
                     return
 
                 if message.type == MessageType.CHALLENGE_ACCEPTED:
@@ -318,7 +323,12 @@ class DeviceReader:
 
                 if decrypted.type == MessageType.PEER_PUBKEY:
                     peer_pubkey_response = self.encryption.msg_peer_pubkey(decrypted)
-                    await self.client.write_gatt_char(WRITE_UUID, peer_pubkey_response)
+                    try:
+                        await self.client.write_gatt_char(
+                            WRITE_UUID, peer_pubkey_response
+                        )
+                    except BleakError as err:
+                        self.logger.warning("Peer pubkey write failed: %s", err)
                     return
 
                 if decrypted.type == MessageType.PUBKEY_ACCEPTED:

--- a/tests/device_reader_test.py
+++ b/tests/device_reader_test.py
@@ -1,10 +1,27 @@
 import asyncio
 import unittest
 
+from bleak.exc import BleakError
+
 from bluetti_bt_lib.base_devices import BaseDeviceV1
 from bluetti_bt_lib import DeviceReader
+from bluetti_bt_lib.bluetooth.device_reader import DeviceReaderConfig
+from bluetti_bt_lib.bluetooth.encryption import KEX_MAGIC, MessageType, hexsum
 from bluetti_bt_lib.fields import FieldName
 from bluetti_bt_lib.utils.bleak_client_mock import ClientMockNoEncryption
+
+
+def build_challenge_frame() -> bytearray:
+    """Build a well-formed pre-key-exchange CHALLENGE frame."""
+    body = bytes([MessageType.CHALLENGE.value, 0]) + b"\x01\x02\x03\x04"
+    return bytearray(KEX_MAGIC + body + hexsum(body, 2))
+
+
+class FailingWriteClient:
+    """BLE client whose writes always fail, as when the peer drops the link."""
+
+    async def write_gatt_char(self, *_args, **_kwargs):
+        raise BleakError("Not connected")
 
 
 class TestDeviceReader(unittest.IsolatedAsyncioTestCase):
@@ -61,3 +78,17 @@ class TestDeviceReader(unittest.IsolatedAsyncioTestCase):
         data = await reader.read()
 
         self.assertIsNone(data.get(FieldName.BATTERY_SOC.value))
+
+    async def test_handshake_write_failure_is_contained(self):
+        # A write can fail mid-handshake when the peripheral drops the link.
+        # The notification handler must not let BleakError escape into bleak's
+        # callback dispatch, where it surfaces without naming the stalled read.
+        reader = DeviceReader(
+            "00:11:00:11:00:11",
+            BaseDeviceV1(),
+            asyncio.Future,
+            config=DeviceReaderConfig(use_encryption=True),
+        )
+        reader.client = FailingWriteClient()
+
+        await reader._notification_handler(0, build_challenge_frame())


### PR DESCRIPTION
Both handshake replies — the challenge response and the peer pubkey — are written with an unguarded `write_gatt_char` inside `_notification_handler`.

Because the handler runs as a bleak notification callback, a `BleakError` raised there does **not** propagate to the caller awaiting `read()`. It surfaces as an unhandled exception from bleak's callback dispatch, with a traceback that never names the read that then stalls until timeout. The failure is real but the log points at the wrong place.

A write can legitimately fail mid-handshake when the peripheral drops the link — common with battery-powered stations that disconnect between polls. Catching `BleakError` turns that into a warning and lets the read time out and retry normally, which is already how the surrounding code handles a lost connection.

Behaviour on success is unchanged; only the failure path is affected.

### Test

Adds a regression test driving `_notification_handler` with a well-formed `CHALLENGE` frame against a client whose `write_gatt_char` always raises. It fails with `bleak.exc.BleakError: Not connected` escaping the handler before the change, and passes after. Full suite green.

### Relation to other open PRs

Not overlapping with #78, which guards the tail of the same handler (already-completed future) — the two are complementary. #67 reworks connection error handling far more broadly; this PR is deliberately minimal and can be dropped if that direction is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)