### PR TITLE
Add Handsfree 2 device registration and CTRL_AC/CTRL_DC control support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Added and mostly validated by contributors (some are moved here from the HA Inte
 |EP500P     |bluetti-mqtt                                                                           |✅                   |✅             |✅             |✅             |✅             |
 |EP760      |[@Apfuntimes](https://github.com/Apfuntimes)                                           |✅                   |PV             |Grid           |❌             |AC Phases      |
 |EP800      |[@jhagenk](https://github.com/jhagenk)                                                 |✅                   |❌             |❌             |❌             |❌             |
+|Handsfree 2|[@pablogiaccaglia](https://github.com/pablogiaccaglia)                                 |✅                   |✅             |✅             |✅             |✅             |
 |PR30V2     |@gentoo90                                                                              |✅                   |✅             |✅             |✅             |✅             |
 |PR100V2    |shares PR30V2 register layout (pending validation)                                     |✅                   |✅             |✅             |✅             |✅             |
 |EL10       |[sidieje](https://github.com/sidieje)                                                  |✅                   |✅             |✅             |✅             |✅             |
@@ -66,6 +67,7 @@ Added and mostly validated by contributors:
 |-----------|---------------------------------------------------------|-------|-------|-------------|---------------|-------------|
 |AC200L     |bluetti-mqtt, [@seaburger](https://github.com/seaburger) |✅     |✅     |✅           |❌             |❌           |
 |EL30V2     |[@x3ccd4828](https://github.com/x3ccd4828)               |✅     |✅     |❌           |❌             |❌           |
+|Handsfree 2|[@pablogiaccaglia](https://github.com/pablogiaccaglia)   |✅     |✅     |❌           |❌             |❌           |
 
 ## Battery pack data
 

--- a/bluetti_bt_lib/devices/__init__.py
+++ b/bluetti_bt_lib/devices/__init__.py
@@ -27,6 +27,7 @@ from .ep760 import EP760
 from .ep800 import EP800
 from .ep2000 import EP2000
 from .handsfree1 import Handsfree1
+from .handsfree2 import Handsfree2
 from .pr30v2 import PR30V2
 from .pr100v2 import PR100V2
 
@@ -59,11 +60,12 @@ DEVICES = {
     "EP800": EP800,
     "EP2000": EP2000,
     "Handsfree 1": Handsfree1,
+    "Handsfree 2": Handsfree2,
     "PR30V2": PR30V2,
     "PR100V2": PR100V2,
 }
 
 # Prefixes of all currently supported devices
 DEVICE_NAME_RE = re.compile(
-    r"^(AC2A|AC2P|AC50B|AC60|AC60P|AC70|AC70P|AC180|AC180T|AC180P|AC200L|AC200M|AC200PL|AC300|AC500|AP300|EB3A|EL10|EL100V2|EL30V2|EP500|EP500P|EP600|EP760|EP800|EP2000|Handsfree\s1|PR30V2|PR100V2)(\d+)$"
+    r"^(AC2A|AC2P|AC50B|AC60|AC60P|AC70|AC70P|AC180|AC180T|AC180P|AC200L|AC200M|AC200PL|AC300|AC500|AP300|EB3A|EL10|EL100V2|EL30V2|EP500|EP500P|EP600|EP760|EP800|EP2000|Handsfree\s[12]|PR30V2|PR100V2)(\d+)$"
 )

--- a/bluetti_bt_lib/devices/handsfree2.py
+++ b/bluetti_bt_lib/devices/handsfree2.py
@@ -1,0 +1,24 @@
+from ..base_devices import BaseDeviceV2
+from ..fields import FieldName, UIntField, DecimalField, SwitchField
+
+
+class Handsfree2(BaseDeviceV2):
+    def __init__(self):
+        super().__init__(
+            [
+                DecimalField(FieldName.TIME_REMAINING, 104, 1),
+                UIntField(FieldName.DC_OUTPUT_POWER, 140),
+                UIntField(FieldName.AC_OUTPUT_POWER, 142),
+                UIntField(FieldName.DC_INPUT_POWER, 144),
+                UIntField(FieldName.AC_INPUT_POWER, 146),
+                DecimalField(FieldName.DC_INPUT_VOLTAGE, 1213, 1),
+                DecimalField(FieldName.DC_INPUT_CURRENT, 1214, 1),
+                DecimalField(FieldName.AC_INPUT_FREQUENCY, 1300, 1),
+                DecimalField(FieldName.AC_INPUT_VOLTAGE, 1314, 1),
+                DecimalField(FieldName.AC_INPUT_CURRENT, 1315, 1),
+                DecimalField(FieldName.AC_OUTPUT_FREQUENCY, 1500, 1),
+                DecimalField(FieldName.AC_OUTPUT_VOLTAGE, 1511, 1),
+                SwitchField(FieldName.CTRL_AC, 2011),
+                SwitchField(FieldName.CTRL_DC, 2012),
+            ],
+        )


### PR DESCRIPTION
Adds the Handsfree 2 (iot v2, encrypted firmware) as a device, mirroring the Handsfree 1 sensor map plus the standard v2 control block.

Validated against a real unit (advertises as `Handsfree 22441000307146`, IoT v9046.01 / ARM v2163.04 / DSP v2162.05), via a full raw register capture (`bluetti-readall -v 2 -e 1`) cross-checked field by field:

- register 102 decoded to the true battery SoC
- registers 110+ decode (SwapString) to `Handsfree 2` + serial
- 1314 / 1511 decoded to 225.0 / 225.1 V with real 50 Hz mains connected
- register 2011 read `1` with the AC output genuinely on; 2012 read `0` with DC off
- **write path verified live**: an encrypted write of `ctrl_dc` (register 2012) on→off round-tripped with valid MODBUS echoes (`010607dc00018884` / `010607dc00004944`) and the read-back state followed both times

Notes:
- Power fields (140–146) returned well-formed zeros — the unit was carrying no load during validation, so their addresses are inherited from Handsfree 1 rather than proven at nonzero draw.
- The write test above used a small DeviceReader subclass that reuses the existing encryption session for writes, since `DeviceWriter` currently refuses encrypted devices — happy to contribute that as a follow-up PR if there's interest (see issue I'll link below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)