### PR TITLE
Add fields to EL100V2

### DIFF
--- a/bluetti_bt_lib/devices/el100v2.py
+++ b/bluetti_bt_lib/devices/el100v2.py
@@ -1,15 +1,44 @@
+from decimal import Decimal
+
+from ..enums import EcoMode, DisplayMode, ChargingMode
+from ..fields import (
+    FieldName,
+    UIntField,
+    SelectField,
+    SwitchField,
+    DecimalField,
+    VersionField,
+    SwapStringField,
+)
 from ..base_devices import BaseDeviceV2
-from ..fields import FieldName, UIntField, DecimalField
 
 
 class EL100V2(BaseDeviceV2):
     def __init__(self):
         super().__init__(
             [
+                DecimalField(FieldName.TIME_REMAINING, 104, 0, 1 / Decimal(60)),
                 UIntField(FieldName.DC_OUTPUT_POWER, 140),
                 UIntField(FieldName.AC_OUTPUT_POWER, 142),
                 UIntField(FieldName.DC_INPUT_POWER, 144),
                 UIntField(FieldName.AC_INPUT_POWER, 146),
                 DecimalField(FieldName.AC_INPUT_VOLTAGE, 1314, 1),
+                DecimalField(FieldName.AC_INPUT_CURRENT, 1315, 1),
+                DecimalField(FieldName.AC_OUTPUT_VOLTAGE, 1511, 1),
+                SwitchField(FieldName.CTRL_AC, 2011),
+                SwitchField(FieldName.CTRL_DC, 2012),
+                SwitchField(FieldName.CTRL_ECO_DC, 2014),
+                SelectField(FieldName.CTRL_ECO_TIME_MODE_DC, 2015, EcoMode),
+                UIntField(FieldName.CTRL_ECO_MIN_POWER_DC, 2016),
+                SwitchField(FieldName.CTRL_ECO_AC, 2017),
+                SelectField(FieldName.CTRL_ECO_TIME_MODE_AC, 2018, EcoMode),
+                UIntField(FieldName.CTRL_ECO_MIN_POWER_AC, 2019),
+                SelectField(FieldName.CTRL_CHARGING_MODE, 2020, ChargingMode),
+                SwitchField(FieldName.CTRL_POWER_LIFTING, 2021),
+                UIntField(FieldName.BATTERY_SOC_RANGE_START, 2022),
+                UIntField(FieldName.BATTERY_SOC_RANGE_END, 2023),
+                SelectField(FieldName.CTRL_DISPLAY_TIMEOUT, 2067, DisplayMode),
+                VersionField(FieldName.VER_BMS, 6175),
+                SwapStringField(FieldName.WIFI_NAME, 12002, 16),
             ],
         )

--- a/bluetti_bt_lib/enums/charging_mode.py
+++ b/bluetti_bt_lib/enums/charging_mode.py
@@ -6,3 +6,4 @@ class ChargingMode(Enum):
     STANDARD = 0
     SILENT = 1
     TURBO = 2
+    CUSTOM = 4


### PR DESCRIPTION
Notes:
Time remaining is stored in minutes and is converted to hours by multiplying by 1/60. The resulting `Decimal` value is displayed by `bluetti_read` as-is, without any rounding (either explicit via `round()` or implicit via conversion to float). Maybe `DecimalField` should be modified to allow specifying rounding precision to avoid this.
Screen timeout is stored at address 2067 as `DisplayMode`.
BMS version is stored at address 6175, but I have not found other version numbers shown in the Bluetti app (IoT, ARM, DSP).
Other added fields are at expected addresses.
Charging mode can be set to "Standard", "Silent", "Turbo" or "Custom". In "Custom" charging mode maximum charging current can be specified in range 1A–6A with 1A step. I have not found where this value is stored.

Current `bluetti_read` output looks like this:
```text
FieldName.BATTERY_SOC: 100%
FieldName.TIME_REMAINING: 68.20000000000000000000000001h
FieldName.DEVICE_TYPE: EL100V2
FieldName.DEVICE_SN: 2527*********
FieldName.DC_OUTPUT_POWER: 0W
FieldName.AC_OUTPUT_POWER: 217W
FieldName.DC_INPUT_POWER: 0W
FieldName.AC_INPUT_POWER: 217W
FieldName.AC_INPUT_VOLTAGE: 236.3V
FieldName.AC_INPUT_CURRENT: 0.9A
FieldName.AC_OUTPUT_VOLTAGE: 236.3V
FieldName.CTRL_AC: True
FieldName.CTRL_DC: True
FieldName.CTRL_ECO_DC: False
FieldName.CTRL_ECO_TIME_MODE_DC: EcoMode.HOURS1
FieldName.CTRL_ECO_MIN_POWER_DC: 6W
FieldName.CTRL_ECO_AC: False
FieldName.CTRL_ECO_TIME_MODE_AC: EcoMode.HOURS1
FieldName.CTRL_ECO_MIN_POWER_AC: 15W
FieldName.CTRL_CHARGING_MODE: ChargingMode.CUSTOM
FieldName.CTRL_POWER_LIFTING: False
FieldName.BATTERY_SOC_RANGE_START: 75%
FieldName.BATTERY_SOC_RANGE_END: 95%
FieldName.CTRL_DISPLAY_TIMEOUT: DisplayMode.NEVER
FieldName.VER_BMS: 1083.07
FieldName.WIFI_NAME: BLUETTI
```